### PR TITLE
upd-added-ai-docs-on-deepwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ OIKAN is a neuro-symbolic machine learning framework inspired by Kolmogorov-Arno
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/silvermete0r/OIKAN.svg)](https://github.com/silvermete0r/oikan/issues)
 [![Docs](https://img.shields.io/badge/docs-passing-brightgreen)](https://silvermete0r.github.io/oikan/)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/silvermete0r/oikan)
 
 > **Important Disclaimer**: OIKAN is an experimental research project. It is not intended for production use or real-world applications. This framework is designed for research purposes, experimentation, and academic exploration of neuro-symbolic machine learning concepts.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,6 +37,9 @@
                     <a href="#examples" class="text-gray-600 hover:text-blue-600">Examples</a>
                     <a href="#contribute" class="text-gray-600 hover:text-blue-600">Contribute</a>
                     <a href="projects.html" class="text-gray-600 hover:text-blue-600">Featured Projects</a>
+                    <a href="https://deepwiki.com/silvermete0r/oikan" target="_blank" class="text-gray-600 hover:text-blue-600">
+                        <span class="px-2 py-1 text-xs font-semibold bg-blue-100 text-blue-800 rounded-full">AI Docs on DeepWiki</span>
+                    </a>
                 </div>
                 <div>
                     <a href="https://github.com/silvermete0r/OIKAN" target="_blank" class="text-gray-600 hover:text-gray-900">


### PR DESCRIPTION
We are indexed in DeepWiki, and now we have our own AI Documentation on OIKAN. Thanks to `Devin - Cognition` team :)

🔗 Link: https://deepwiki.com/silvermete0r/oikan