### PR TITLE
Google Colab + Kaggle: Added Get Started Tutorial Notebook for both Classification and Regression tasks! 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ OIKAN is a neuro-symbolic machine learning framework inspired by Kolmogorov-Arno
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![GitHub issues](https://img.shields.io/github/issues/silvermete0r/OIKAN.svg)](https://github.com/silvermete0r/oikan/issues)
 [![Docs](https://img.shields.io/badge/docs-passing-brightgreen)](https://silvermete0r.github.io/oikan/)
+
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/silvermete0r/oikan)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/silvermete0r/oikan/blob/main/examples/oikan-v0-0-3-get-started-template-notebook.ipynb)
+[![Open In Kaggle](https://kaggle.com/static/images/open-in-kaggle.svg)](https://www.kaggle.com/code/armanzhalgasbayev/oikan-v0-0-3-get-started-template-notebook)
+
 
 > **Important Disclaimer**: OIKAN is an experimental research project. It is not intended for production use or real-world applications. This framework is designed for research purposes, experimentation, and academic exploration of neuro-symbolic machine learning concepts.
 

--- a/README.md
+++ b/README.md
@@ -92,9 +92,20 @@ cd OIKAN
 pip install -e .  # Install in development mode
 ```
 
+#### System Requirements
+
+| Requirement       | Details                              |
+|-------------------|--------------------------------------|
+| Python            | Version 3.7 or higher               |
+| Operating System  | Platform independent (Windows/macOS/Linux) |
+| Memory            | Recommended minimum 4GB RAM         |
+| Disk Space        | ~100MB for installation (including dependencies) |
+| GPU               | Optional (for faster training)      |
+| Dependencies      | torch, numpy, scikit-learn, sympy, tqdm   |
+
 ### Regression Example
 ```python
-from oikan.model import OIKANRegressor
+from oikan import OIKANRegressor
 from sklearn.metrics import mean_squared_error
 
 # Initialize model
@@ -143,7 +154,7 @@ loaded_model.load("outputs/model.json")
 
 ### Classification Example
 ```python
-from oikan.model import OIKANClassifier
+from oikan import OIKANClassifier
 from sklearn.metrics import accuracy_score
 
 # Initialize model

--- a/docs/index.html
+++ b/docs/index.html
@@ -132,7 +132,7 @@ pip install -e .</code></pre>
             
             <div class="bg-white rounded-lg shadow-lg p-6 mb-6">
                 <h3 class="text-xl font-semibold mb-4">Regression Example</h3>
-                <pre class="language-python"><code>from oikan.model import OIKANRegressor
+                <pre class="language-python"><code>from oikan import OIKANRegressor
 from sklearn.metrics import r2_score
 
 # Initialize model
@@ -178,7 +178,7 @@ loaded_model.load("outputs/model.json")</code></pre>
 
             <div class="bg-white rounded-lg shadow-lg p-6">
                 <h3 class="text-xl font-semibold mb-4">Classification Example</h3>
-                <pre class="language-python"><code>from oikan.model import OIKANClassifier
+                <pre class="language-python"><code>from oikan import OIKANClassifier
 from sklearn.metrics import accuracy_score
 
 # Initialize model

--- a/examples/classification_tutorial.py
+++ b/examples/classification_tutorial.py
@@ -59,7 +59,7 @@ for formula in formulas_loaded:
     print(formula)
 
 print("Simplified Formulas:")
-simplified_formulas = loaded_model.get_formula(type='sympied')
+simplified_formulas = loaded_model.get_formula(type='sympy')
 for simplified_formula in simplified_formulas:
     print(simplified_formula)
 

--- a/examples/oikan-v0-0-3-get-started-template-notebook.ipynb
+++ b/examples/oikan-v0-0-3-get-started-template-notebook.ipynb
@@ -1,0 +1,1392 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0bbebcb2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007282,
+     "end_time": "2025-05-11T18:48:18.070610",
+     "exception": false,
+     "start_time": "2025-05-11T18:48:18.063328",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "<div style=\"text-align: center;\">\n",
+    "  <img src=\"https://github.com/silvermete0r/oikan/blob/main/docs/media/oikan_logo.png?raw=true\" width=\"120\">\n",
+    "</div>\n",
+    "\n",
+    "# OIKAN: Neuro-Symbolic ML for Scientific Discovery\n",
+    "\n",
+    "OIKAN is a neuro-symbolic machine learning framework inspired by Kolmogorov-Arnold representation theorem. It combines the power of modern neural networks with techniques for extracting clear, interpretable symbolic formulas from data. OIKAN is designed to make machine learning models both accurate and Interpretable.\n",
+    "\n",
+    "* GitHub: https://github.com/silvermete0r/oikan\n",
+    "* PyPI: https://pypi.org/project/oikan/\n",
+    "\n",
+    "## 👋 Welcome to the OIKAN Get Started Template!\n",
+    "\n",
+    "This notebook demonstrates how to use the OIKAN v0.0.3 library for both classification and regression tasks. It includes:\n",
+    "* Classification using the Iris dataset with `OIKANClassifier`.\n",
+    "* Regression using the California Housing dataset with `OIKANRegressor`.\n",
+    "* Extracting symbolic formulas, feature importances, and saving/loading models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "088a9edd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005634,
+     "end_time": "2025-05-11T18:48:18.082589",
+     "exception": false,
+     "start_time": "2025-05-11T18:48:18.076955",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 1. Setup and Installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5ad3b083",
+   "metadata": {
+    "_cell_guid": "b1076dfc-b9ad-4769-8c92-a6c4dae69d19",
+    "_uuid": "8f2839f25d086af736a60e9eeb907d3b93b6e0e5",
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:48:18.097276Z",
+     "iopub.status.busy": "2025-05-11T18:48:18.096908Z",
+     "iopub.status.idle": "2025-05-11T18:50:00.953567Z",
+     "shell.execute_reply": "2025-05-11T18:50:00.951865Z"
+    },
+    "papermill": {
+     "duration": 102.866434,
+     "end_time": "2025-05-11T18:50:00.956317",
+     "exception": false,
+     "start_time": "2025-05-11T18:48:18.089883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m363.4/363.4 MB\u001b[0m \u001b[31m3.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m664.8/664.8 MB\u001b[0m \u001b[31m1.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m211.5/211.5 MB\u001b[0m \u001b[31m7.2 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m56.3/56.3 MB\u001b[0m \u001b[31m24.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m127.9/127.9 MB\u001b[0m \u001b[31m12.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m207.5/207.5 MB\u001b[0m \u001b[31m7.1 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m21.1/21.1 MB\u001b[0m \u001b[31m58.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0m\r\n",
+      "\u001b[?25h\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\r\n",
+      "pylibcugraph-cu12 24.12.0 requires pylibraft-cu12==24.12.*, but you have pylibraft-cu12 25.2.0 which is incompatible.\r\n",
+      "pylibcugraph-cu12 24.12.0 requires rmm-cu12==24.12.*, but you have rmm-cu12 25.2.0 which is incompatible.\u001b[0m\u001b[31m\r\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "# Install OIKAN v0.0.3 quietly\n",
+    "!pip install -qU oikan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f48facc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:01.029135Z",
+     "iopub.status.busy": "2025-05-11T18:50:01.028650Z",
+     "iopub.status.idle": "2025-05-11T18:50:03.545366Z",
+     "shell.execute_reply": "2025-05-11T18:50:03.544058Z"
+    },
+    "papermill": {
+     "duration": 2.55617,
+     "end_time": "2025-05-11T18:50:03.547441",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:00.991271",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "oikan==0.0.3.5\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "# (Optional) Verify installation\n",
+    "!pip freeze | grep oikan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3a4edc3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:03.613825Z",
+     "iopub.status.busy": "2025-05-11T18:50:03.613454Z",
+     "iopub.status.idle": "2025-05-11T18:50:03.738380Z",
+     "shell.execute_reply": "2025-05-11T18:50:03.736815Z"
+    },
+    "papermill": {
+     "duration": 0.160528,
+     "end_time": "2025-05-11T18:50:03.740367",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:03.579839",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# (Optional) Create output directory for saving models\n",
+    "!mkdir -p outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2afe7067",
+   "metadata": {
+    "papermill": {
+     "duration": 0.031637,
+     "end_time": "2025-05-11T18:50:03.804957",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:03.773320",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 2. Classification: Iris Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "01582de8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:03.872196Z",
+     "iopub.status.busy": "2025-05-11T18:50:03.871826Z",
+     "iopub.status.idle": "2025-05-11T18:50:13.649631Z",
+     "shell.execute_reply": "2025-05-11T18:50:13.648640Z"
+    },
+    "papermill": {
+     "duration": 9.814823,
+     "end_time": "2025-05-11T18:50:13.651488",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:03.836665",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import accuracy_score, classification_report\n",
+    "from oikan import OIKANClassifier\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "adea9737",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:13.839745Z",
+     "iopub.status.busy": "2025-05-11T18:50:13.838711Z",
+     "iopub.status.idle": "2025-05-11T18:50:13.852613Z",
+     "shell.execute_reply": "2025-05-11T18:50:13.851434Z"
+    },
+    "papermill": {
+     "duration": 0.051229,
+     "end_time": "2025-05-11T18:50:13.854562",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:13.803333",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load Iris dataset\n",
+    "data = load_iris()\n",
+    "X, y = data.data, data.target\n",
+    "feature_names = data.feature_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "388c0fa4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:13.923494Z",
+     "iopub.status.busy": "2025-05-11T18:50:13.923064Z",
+     "iopub.status.idle": "2025-05-11T18:50:13.934922Z",
+     "shell.execute_reply": "2025-05-11T18:50:13.934043Z"
+    },
+    "papermill": {
+     "duration": 0.04892,
+     "end_time": "2025-05-11T18:50:13.936691",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:13.887771",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Split into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e6e87abb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:14.004915Z",
+     "iopub.status.busy": "2025-05-11T18:50:14.004504Z",
+     "iopub.status.idle": "2025-05-11T18:50:14.011049Z",
+     "shell.execute_reply": "2025-05-11T18:50:14.010131Z"
+    },
+    "papermill": {
+     "duration": 0.043105,
+     "end_time": "2025-05-11T18:50:14.012640",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:13.969535",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize OIKANClassifier\n",
+    "model = OIKANClassifier(\n",
+    "    hidden_sizes=[32, 32],\n",
+    "    activation='relu',\n",
+    "    augmentation_factor=10,\n",
+    "    alpha=0.1,\n",
+    "    sigma=0.1,\n",
+    "    epochs=100,\n",
+    "    lr=0.001,\n",
+    "    batch_size=32,\n",
+    "    top_k=10,\n",
+    "    evaluate_nn=False,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ac8ddd04",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:14.080685Z",
+     "iopub.status.busy": "2025-05-11T18:50:14.080227Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.467062Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.465933Z"
+    },
+    "papermill": {
+     "duration": 4.422406,
+     "end_time": "2025-05-11T18:50:18.468791",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:14.046385",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.11/dist-packages/oikan/model.py:290: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "  torch.tensor(y, dtype=torch.float32))\n",
+      "Training: 100%|██████████| 100/100 [00:01<00:00, 88.25it/s, loss=0.0845]\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 2.006e+02, tolerance: 5.915e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 7.844e+00, tolerance: 1.491e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 2.258e+02, tolerance: 7.014e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 2.764e+02, tolerance: 5.915e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 5.375e+01, tolerance: 1.491e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data: features shape: (120, 4) | target shape: (120,)\n",
+      "Augmented data: features shape: (1200, 4) | target shape: (1200, 3)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 2.970e+02, tolerance: 7.014e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fit the model\n",
+    "model.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "17641a38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:18.550839Z",
+     "iopub.status.busy": "2025-05-11T18:50:18.550476Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.566406Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.565458Z"
+    },
+    "papermill": {
+     "duration": 0.060073,
+     "end_time": "2025-05-11T18:50:18.568228",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.508155",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Make predictions\n",
+    "y_pred = model.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "01411142",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:18.650024Z",
+     "iopub.status.busy": "2025-05-11T18:50:18.649339Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.656176Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.655242Z"
+    },
+    "papermill": {
+     "duration": 0.050736,
+     "end_time": "2025-05-11T18:50:18.657657",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.606921",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Accuracy: 1.0000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluate accuracy\n",
+    "accuracy = accuracy_score(y_test, y_pred)\n",
+    "print(f\"Accuracy: {accuracy:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "805eba2d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:18.741850Z",
+     "iopub.status.busy": "2025-05-11T18:50:18.741495Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.758555Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.757338Z"
+    },
+    "papermill": {
+     "duration": 0.06075,
+     "end_time": "2025-05-11T18:50:18.760186",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.699436",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Classification Report:\n",
+      "              precision    recall  f1-score   support\n",
+      "\n",
+      "           0       1.00      1.00      1.00        10\n",
+      "           1       1.00      1.00      1.00         9\n",
+      "           2       1.00      1.00      1.00        11\n",
+      "\n",
+      "    accuracy                           1.00        30\n",
+      "   macro avg       1.00      1.00      1.00        30\n",
+      "weighted avg       1.00      1.00      1.00        30\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print classification report\n",
+    "print(\"\\nClassification Report:\")\n",
+    "print(classification_report(y_test, y_pred))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c8036870",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:18.841819Z",
+     "iopub.status.busy": "2025-05-11T18:50:18.841409Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.847513Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.846414Z"
+    },
+    "papermill": {
+     "duration": 0.048565,
+     "end_time": "2025-05-11T18:50:18.849086",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.800521",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Symbolic Formulas:\n",
+      "Class 0 Formula: Class 0: 0.502330*x0 + 0.047963*x1 + 0.068156*x0^2 + 0.060449*x0 x1 + -0.348062*x0 x2 + -0.302223*x0 x3 + 0.788278*x1^2 + -0.205325*x1 x2 + -0.123608*x1 x3 + -0.158860*x2^2 + 0.020679*x0^3 + -0.001237*exp_x0 + -0.104283*exp_x1 + 0.000461*x2^3 + 0.006598*exp_x2 + 0.370910*sin_x2 + 0.007158*x3^3\n",
+      "Class 1 Formula: Class 1: 0.095236*x0 + 0.164205*x0^2 + 0.029835*x0 x1 + 0.002185*x0 x2 + 0.101242*x1 x2 + -0.016630*x2^2 + -0.123284*x2 x3 + -0.007198*x0^3 + -0.000386*exp_x0 + -0.003938*exp_x1 + -0.026264*x2^3 + 0.004455*exp_x2 + -0.037553*x3^3\n",
+      "Class 2 Formula: Class 2: -0.713402*x0 + -0.156225*x1 + -0.109722*x0^2 + -0.039182*x0 x1 + 0.293238*x0 x2 + 0.401316*x0 x3 + -0.732060*x1^2 + 0.093550*x1 x2 + 0.104036*x1 x3 + 0.216042*x2^2 + -0.020035*x0^3 + 0.001268*exp_x0 + 0.100670*exp_x1 + 0.014878*x2^3 + -0.008931*exp_x2 + -0.299646*sin_x2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get symbolic formulas for each class\n",
+    "print(\"\\nSymbolic Formulas:\")\n",
+    "formulas = model.get_formula()\n",
+    "for i, formula in enumerate(formulas):\n",
+    "    print(f\"Class {i} Formula: {formula}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "64f6189d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:18.928759Z",
+     "iopub.status.busy": "2025-05-11T18:50:18.928423Z",
+     "iopub.status.idle": "2025-05-11T18:50:18.934431Z",
+     "shell.execute_reply": "2025-05-11T18:50:18.933386Z"
+    },
+    "papermill": {
+     "duration": 0.048511,
+     "end_time": "2025-05-11T18:50:18.936013",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.887502",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Feature Importances:\n",
+      "[0.34342276 0.29054357 0.24734127 0.1186924 ]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get feature importances\n",
+    "print(\"\\nFeature Importances:\")\n",
+    "importances = model.feature_importances()\n",
+    "print(importances)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "a511dd43",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:19.014031Z",
+     "iopub.status.busy": "2025-05-11T18:50:19.013661Z",
+     "iopub.status.idle": "2025-05-11T18:50:19.304340Z",
+     "shell.execute_reply": "2025-05-11T18:50:19.303323Z"
+    },
+    "papermill": {
+     "duration": 0.331279,
+     "end_time": "2025-05-11T18:50:19.306239",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:18.974960",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAJOCAYAAAAqFJGJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuNSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/xnp5ZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACI2UlEQVR4nOzdeXxM1+P/8fdkFySxxlK11Fa1FUXtJcRWlNZSLVJbi6KpXWstQdGotVpU7a2dr9qCqtq32lVVLdXEVglBIsn5/eGX+WQklIxkaF7Px2Me5M65Z85NztyZ973nnmsxxhgBAAAAgB2cHN0AAAAAAM8+ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQCkEadOnVKdOnXk7e0ti8Wi5cuXO7pJVt9++60sFov+/PNPRzflP2/MmDEqWrSo4uLiHN2Up8Kff/4pi8Wib7/91mFtyJcvn9q1a2ezLKn3a0q9T1q2bKnmzZs/0TqRNhEsgEcQvzNP6tGvX78Uec3t27dryJAhun79eorUb4/438fevXsd3ZRkmzJlikO/SDhC27ZtdfjwYY0YMUJz5sxRuXLlUuy14r+sjR07NsVe40Fq1KhhfX86OTnJy8tLRYoU0bvvvqsNGzbYVffT1G8uXryoIUOG6ODBg4+8TkREhEaPHq2+ffvKycn2K0BkZKSGDx+ukiVLytPTU97e3qpataq+++47GWMS1WWxWNStWzfrzw/6mxtj1LlzZ1ksFg0ZMiRRPX369JHFYlGLFi2SbHN8vRaLRUuWLEn0/JAhQ2SxWHTlypVEz23ZskVNmzZVjhw55ObmpuzZs+v111/X0qVLk3ytp0lqvl/79u2rJUuW6Ndff02x10Da4OLoBgDPkmHDhil//vw2y4oXL54ir7V9+3YNHTpU7dq1k4+PT4q8Rlo2ZcoUZc2aNdFRwv+q27dva8eOHRo4cKDNl8GnxbvvvquWLVvK3d39idT33HPPKSgoSNK9L8y///67li5dqrlz56p58+aaO3euXF1dH7vep6nfXLx4UUOHDlW+fPlUunTpR1pn5syZiomJUatWrWyWh4WFqVatWjp+/Lhatmypbt266c6dO1qyZInatm2rNWvWaN68eXJ2dn6sNhpj1KVLF02fPl2ffvppomBhjNGCBQuUL18+rVq1Sjdu3FDGjBkfWN+wYcPUtGlTWSyWf33twYMHa9iwYSpUqJA6d+6svHnz6urVq1qzZo2aNWumefPm6e23336s7UkpJ0+etAl6D3q/Pun3SbyXX35Z5cqV07hx4/Tdd9890bqRthAsgMdQr169FD1qlBoiIyOVPn16RzfDYW7duiVPT09HNyPVXb58WZKeaEh9En0pvg5nZ+fH/tL6MN7e3nrnnXdslo0aNUrdu3fXlClTlC9fPo0ePfqJvd6zYtasWWrUqJE8PDxslrdt21bHjx/XsmXL1KhRI+vy7t27q3fv3ho7dqxefvll9e3b97Fe78MPP9S0adM0cOBADRs2LNHzW7Zs0YULF7Rp0yb5+/tr6dKlatu2bZJ1lS5dWgcPHtSyZcvUtGnTh77u4sWLNWzYML355puaP3++TYjs3bu31q1bp7t37z7WtqSk+4PCg96vT/p9kvA93Lx5cw0ePFhTpkxRhgwZnthrII0xAP7VrFmzjCSzZ8+eh5Zbs2aNqVKlivH09DQZMmQw9evXN0eOHLEp8+uvv5q2bdua/PnzG3d3d+Pr62sCAgLMlStXrGUGDx5sJCV6nDlzxpw5c8ZIMrNmzUr0+pLM4MGDE9Vz9OhR06pVK+Pj42NKly5tfX7OnDmmTJkyxsPDw2TKlMm0aNHCnDt3Llm/j7Zt25r06dObs2fPmgYNGpj06dObXLlymUmTJhljjDl06JB57bXXjKenp3n++efNvHnzkqzzp59+Mp06dTKZM2c2GTNmNO+++665du1aojZMnjzZFCtWzLi5uZmcOXOaLl26mH/++cemTPXq1c1LL71k9u7da6pWrWrSpUtnevToYfLmzZvod1u9enVjjDFXr141H3/8sSlevLhJnz69yZgxo6lbt645ePCgTd2bN282ksyiRYvMZ599ZnLnzm3c3d1NzZo1zalTpxK1d+fOnaZevXrGx8fHeHp6mhIlSpjg4GCbMsePHzfNmjUzmTJlMu7u7qZs2bJmxYoVNmWio6PNkCFDTMGCBY27u7vJnDmzqVy5slm/fv0D/15J9ae8efNan9+/f7+pW7euyZgxo0mfPr2pWbOm2bFjR5J/ny1btpgPPvjAZMuWzfj4+DzwNeP76eeff/5IdcQ/d+bMGWv5PXv2mDp16pgsWbIYDw8Pky9fPhMQEPDA14wX/3dPSkxMjClWrJjx9PQ0169fty6fOXOmee2110y2bNmMm5ubefHFF82UKVNs1n0S/cYYY7788ktTrFgxky5dOuPj42PKli2b6P1w4cIFExAQYLJnz27c3NxMsWLFzIwZM6zPx/e/+x9J7Rfi/fHHH0aS+fbbb22W79ixw0gy7733XpLr3b171xQqVMhkypTJ3Lp1y7pckunatav15/v/5t27dzeSTP/+/R/Ypvbt25tixYoZY4ypV6+eqV27dqIy8fWOGjXKFC5c2JQqVcrExcVZn4/v35cvX7YuK1q0qMmcObOJiIh44GvfX3/C392j7KeNMSYiIsK6T3FzczPZsmUzfn5+Zt++fdYyv/32m2natKnx9fU17u7uJnfu3KZFixY2/S9v3rymbdu2NtuT1Ps1qfeJMY/22RO/j/79999NvXr1TIYMGUzjxo1ttlmSWbp06b/+zoAH4YwF8BjCw8MTjePNmjWrJGnOnDlq27at/P39NXr0aN26dUtTp05VlSpVdODAAeXLl0+StGHDBv3xxx8KCAhQjhw5dPToUU2fPl1Hjx7Vzp07ZbFY1LRpU/32229asGCBvvjiC+trZMuWzXok63G89dZbKlSokEaOHGkdKz1ixAh9+umnat68uTp06KDLly9r4sSJqlatmg4cOJCsI9uxsbGqV6+eqlWrpjFjxmjevHnq1q2b0qdPr4EDB6p169Zq2rSppk2bpjZt2ujVV19NNLSsW7du8vHx0ZAhQ3Ty5ElNnTpVZ8+e1ZYtW6zDH4YMGaKhQ4fKz89PH3zwgbXcnj179Msvv9gcnbx69arq1aunli1b6p133pGvr69q1KihDz/8UBkyZNDAgQMlSb6+vpKkP/74Q8uXL9dbb72l/PnzKywsTF999ZWqV6+uY8eOKVeuXDbtHTVqlJycnNSrVy+Fh4drzJgxat26tXbt2mUts2HDBjVs2FA5c+ZUjx49lCNHDh0/flyrV69Wjx49JElHjx5V5cqVlTt3bvXr10/p06fX999/ryZNmmjJkiV64403rNseFBSkDh06qHz58oqIiNDevXu1f/9+1a5dO8m/S9OmTeXj46OPPvpIrVq1Uv369a1HJI8ePaqqVavKy8tLffr0kaurq7766ivVqFFDP/30kypUqGBTV5cuXZQtWzYNGjRIkZGRj9dBHqOOS5cuqU6dOsqWLZv69esnHx8f/fnnn3aPjXd2dlarVq306aefatu2bWrQoIEkaerUqXrppZfUqFEjubi4aNWqVerSpYvi4uLUtWtXSVJwcLDd/ebrr79W9+7d9eabb6pHjx66c+eODh06pF27dlmH5YSFhalixYrWaxiyZcumH3/8Ue3bt1dERIR69uypF198UcOGDdOgQYPUqVMnVa1aVZJUqVKlB2779u3bJUllypSxWb5q1SpJUps2bZJcz8XFRW+//baGDh2qX375RX5+fv/6e/7oo4/05Zdfqm/fvho5cmSSZaKiorRkyRJ9/PHHkqRWrVopICBAoaGhypEjR6Lyzs7O+uSTT9SmTZuHnrU4deqUTpw4offee++hw6oe5lH205L0/vvva/HixerWrZuKFSumq1evatu2bTp+/LjKlCmj6Oho+fv7KyoqSh9++KFy5Mihv/76S6tXr9b169fl7e2d6LUf9n5NyqN+9khSTEyM/P39VaVKFY0dO9bm7G2xYsWULl06/fLLL9b9DfDYHJ1sgGdB/FGipB7GGHPjxg3j4+NjOnbsaLNeaGio8fb2tlme8IhfvAULFhhJZuvWrdZln3/+eZJHppJzxqJVq1Y25f7880/j7OxsRowYYbP88OHDxsXFJdHyB/0+7j9jIcmMHDnSuuyff/4x6dKlMxaLxSxcuNC6/MSJE4naGl9n2bJlTXR0tHX5mDFjjCTrkftLly4ZNzc3U6dOHRMbG2stN2nSJCPJzJw507qsevXqRpKZNm1aom146aWXrEebE7pz545Nvcbc+527u7ubYcOGWZfFHzF+8cUXTVRUlHX5hAkTjCRz+PBhY8y9I+T58+c3efPmTXRGJeFR11q1apkSJUqYO3fu2DxfqVIlU6hQIeuyUqVKmQYNGiRq979J6gyCMcY0adLEuLm5mdOnT1uXXbx40WTMmNFUq1bNuiz+71OlShUTExOTrNd7WB33H4ldtmzZI50lTMrDzlgkrHvChAnWZUm9L/39/U2BAgVsltnbbxo3bvzQthlz7yh+zpw5Ex0db9mypfH29ra2dc+ePf96liKhTz75xEgyN27csFnepEkTIylR/0xo6dKlRpL58ssvrcv0gDMW8Wd2evfu/dD2LF682EiynuGLiIgwHh4e5osvvrApl7AvxcTEmEKFCtmctbj/jMWKFSuMpET1PEhS+9RH3U97e3vb/A7ud+DAASPJ/PDDDw9tQ8IzFgnbdP/79f73yeN89sTvo/v16/fAdhQuXNjUq1fvoW0FHoZZoYDHMHnyZG3YsMHmId07unX9+nW1atVKV65csT6cnZ1VoUIFbd682VpHunTprP+/c+eOrly5oooVK0qS9u/fnyLtfv/9921+Xrp0qeLi4tS8eXOb9ubIkUOFChWyae/j6tChg/X/Pj4+KlKkiNKnT28zlWGRIkXk4+OjP/74I9H6nTp1sjnj8MEHH8jFxUVr1qyRJG3cuFHR0dHq2bOnzcWOHTt2lJeXl/7v//7Ppj53d3cFBAQ8cvvd3d2t9cbGxurq1avKkCGDihQpkuTfJyAgQG5ubtaf448cx2/bgQMHdObMGfXs2TPRWaD4o57Xrl3Tpk2b1Lx5c924ccP697h69ar8/f116tQp/fXXX5Lu/U6PHj2qU6dOPfI2PUhsbKzWr1+vJk2aqECBAtblOXPm1Ntvv61t27YpIiLCZp2OHTvaPcb7UeqI/12tXr36iY+Fjz/6e+PGDeuyhO/L+DOT1atX1x9//KHw8PB/rfNR+42Pj48uXLigPXv2JFmPMUZLlizR66+/LmOMzfvT399f4eHhyd5PXL16VS4uLomOfsf/Hh52dD/+ufv7Q1LCwsIkSYULF35ouXnz5qlcuXIqWLCg9TUaNGigefPmPXCd+LMWv/766wOnS45vY3LPVkiPvp/28fHRrl27dPHixSTriT8jsW7dOt26dSvZ7XmQx/nsiffBBx88sL5MmTIlObsW8KgIFsBjKF++vPz8/Gwekqxf8mrWrKls2bLZPNavX69Lly5Z67h27Zp69OghX19fpUuXTtmyZbMOB3qULzDJcf9wo1OnTskYo0KFCiVq7/Hjx23a+zg8PDyULVs2m2Xe3t567rnnEs3i4u3trX/++SdRHYUKFbL5OUOGDMqZM6d13vazZ89KuhdOEnJzc1OBAgWsz8fLnTu3zRf/fxMXF6cvvvhChQoVkru7u7Jmzaps2bLp0KFDSf59nn/+eZufM2XKJEnWbTt9+rSkh88e9vvvv8sYo08//TTR32Pw4MGSZP2bDBs2TNevX1fhwoVVokQJ9e7dW4cOHXrk7Uvo8uXLunXrVqLfpSS9+OKLiouL0/nz522W39+XkuNR6qhevbqaNWumoUOHKmvWrGrcuLFmzZqlqKgou1//5s2bkmy/eMYP8UmfPr18fHyULVs2DRgwQNKjvS8ftd/07dtXGTJkUPny5VWoUCF17dpVv/zyi/X5y5cv6/r165o+fXqivhAfkJP7/nyQ+N9DwqB1v0cJH/H69u2rV155RZ07d9bixYuTLHP9+nWtWbNG1atX1++//259VK5cWXv37tVvv/32wPpbt26tggULatiwYUlOg+vl5fWv2/NvHnU/PWbMGB05ckR58uRR+fLlNWTIEJsDJvnz51dgYKC++eYbZc2aVf7+/po8efIT29c/zmePdG9Y23PPPffA+owxjzTjFvAgXGMBPAHxN5qaM2dOkmODXVz+91Zr3ry5tm/frt69e6t06dLKkCGD4uLiVLdu3Ue6YdWDdvqxsbEPXCfh0bf49losFv34449JHjlO7owgDzoK/aDlSX0peNLu3/Z/M3LkSH366ad67733NHz4cGXOnFlOTk7q2bNnkn+fJ7Ft8fX26tVL/v7+SZaJP6pbrVo1nT59WitWrND69ev1zTff6IsvvtC0adNszhallMf9fSa3DovFosWLF2vnzp1atWqV1q1bp/fee0/jxo3Tzp077Zq15siRI5L+9zs9ffq0atWqpaJFi2r8+PHKkyeP3NzctGbNGn3xxReP9L581H7z4osv6uTJk1q9erXWrl2rJUuWaMqUKRo0aJCGDh1qLfvOO+88cHakkiVLJmu7s2TJopiYmERTur744otavny5Dh06pGrVqiW5bnx4LVas2L++ToYMGfTjjz+qWrVqat26tby8vFSnTh2bMj/88IOioqI0btw4jRs3LlEd8+bN09ChQ5OsP/6sRbt27bRixYpEzxctWlSSdPjw4X9t64M86n66efPmqlq1qpYtW6b169fr888/1+jRo7V06VLVq1dPkjRu3DhrW9evX6/u3bsrKChIO3fufOiX/EfxOJ89ku2ZtaT8888/iQ7uAI+DYAE8AS+88IIkKXv27A+9sPGff/5RSEiIhg4dqkGDBlmXJzWs5UEBIv6I+P03zrv/SP2/tdcYo/z58//rcIXUdurUKb322mvWn2/evKm///5b9evXlyTlzZtX0r153xMO34mOjtaZM2ce6cJS6cG/38WLF+u1117TjBkzbJZfv37dehH944jvG0eOHHlg2+K3w9XV9ZHanzlzZgUEBCggIEA3b95UtWrVNGTIkMcOFtmyZZOnp6dOnjyZ6LkTJ07IyclJefLkeaw6n7SKFSuqYsWKGjFihObPn6/WrVtr4cKFyQ5RsbGxmj9/vjw9PVWlShVJ9y5ejoqK0sqVK23OQCU1jORJ9Jv06dOrRYsWatGihaKjo9W0aVONGDFC/fv3V7Zs2ZQxY0bFxsb+a1943CPL8V+4z5w5YxNOGjZsqKCgIH333XdJBov431mmTJlUuXLlR3qtLFmyaP369apcubKaNm2qDRs26NVXX7U+P2/ePBUvXtx6Ri6hr776SvPnz39gsJDuBa/PPvtMQ4cOtZkeV7o3BKtIkSJasWKFJkyY8Ngh9HH209K9oYNdunRRly5ddOnSJZUpU0YjRoywBgtJKlGihEqUKKFPPvlE27dvV+XKlTVt2jR99tlnj9W2+z3qZ8+jiImJ0fnz5xP9PoHHwVAo4Anw9/eXl5eXRo4cmeR48PiZnOKPbt9/NDs4ODjROvFzi98fILy8vJQ1a1Zt3brVZvmUKVMeub1NmzaVs7Ozhg4dmqgtxhhdvXr1ket60qZPn27zO5w6dapiYmKsH9J+fn5yc3PTl19+adP2GTNmKDw83DrLz79Jnz59knc1d3Z2TvQ7+eGHH6zXODyuMmXKKH/+/AoODk70evGvkz17dtWoUUNfffWV/v7770R1JJwJ7P6/TYYMGVSwYMFkDRFydnZWnTp1tGLFCutQM+neGPn58+erSpUq1mElqe2ff/5J9HeIvwlccodDxcbGqnv37jp+/Li6d+9u3bak3pfh4eGaNWtWojrs7Tf3//3c3NxUrFgxGWN09+5dOTs7q1mzZlqyZIn1zEpCCfvCg/YRDxL/xX7v3r02yytVqiQ/Pz/NmjVLq1evTrTewIED9dtvv6lPnz6PdcYqd+7c2rBhg9KnT68GDRpYzyCcP39eW7duVfPmzfXmm28megQEBOj333+3mVntfvFnLQ4ePKiVK1cmen7o0KG6evWqOnTooJiYmETPr1+/Psltja9b+vf9dGxsbKIhTdmzZ1euXLmsfTQiIiLR65coUUJOTk5PZFjfo372PIpjx47pzp07D51ZDPg3nLEAngAvLy9NnTpV7777rsqUKaOWLVsqW7ZsOnfunP7v//5PlStX1qRJk+Tl5WWdivXu3bvKnTu31q9frzNnziSqs2zZspLufai3bNlSrq6uev3115U+fXp16NBBo0aNUocOHVSuXDlt3br1oWOS7/fCCy/os88+U//+/fXnn3+qSZMmypgxo86cOaNly5apU6dO6tWr1xP7/TyO6Oho1apVS82bN9fJkyc1ZcoUValSxXoULVu2bOrfv7+GDh2qunXrqlGjRtZyr7zySqKboj1I2bJlNXXqVH322WcqWLCgsmfPrpo1a6phw4YaNmyYAgICVKlSJR0+fFjz5s2zOTvyOJycnDR16lS9/vrrKl26tAICApQzZ06dOHFCR48e1bp16yTdmxigSpUqKlGihDp27KgCBQooLCxMO3bs0IULF/Trr79KujcUpUaNGipbtqwyZ86svXv3Wqe7TI7PPvtMGzZsUJUqVdSlSxe5uLjoq6++UlRUlMaMGZOsOp+E2bNna8qUKXrjjTf0wgsv6MaNG/r666/l5eVlPXv1MOHh4Zo7d66kezdFjL/z9unTp9WyZUsNHz7cWrZOnTpyc3PT66+/rs6dO+vmzZv6+uuvlT179kRBz95+U6dOHeXIkUOVK1eWr6+vjh8/rkmTJqlBgwbW4UmjRo3S5s2bVaFCBXXs2FHFihXTtWvXtH//fm3cuFHXrl2TdO997OPjo2nTpiljxoxKnz69KlSo8MBrWAoUKKDixYtr48aNeu+992ye++6771SrVi01btxYb7/9tqpWraqoqCgtXbpUW7ZsUYsWLdS7d+9//b3fr1ChQlq3bp1q1Kghf39/bdu2TT/88IOMMQ88Ml6/fn25uLho3rx5iaY7Tqh169YaPny4Dh48mOi5Fi1a6PDhwxoxYoQOHDigVq1aWe+8vXbtWoWEhGj+/PlJ1vuo++kbN27oueee05tvvqlSpUopQ4YM2rhxo/bs2WMd3rVp0yZ169ZNb731lgoXLqyYmBjNmTPHGiDt9aifPY9iw4YN8vT0fOC01cAjSdU5qIBn1KPeIG/z5s3G39/feHt7Gw8PD/PCCy+Ydu3amb1791rLXLhwwbzxxhvGx8fHeHt7m7feestcvHgx0fSrxhgzfPhwkzt3buPk5GQzxeCtW7dM+/btjbe3t8mYMaNp3ry5uXTp0gOnm01446iElixZYqpUqWLSp09v0qdPb4oWLWq6du1qTp48+di/j/ibL93vQVN/5s2b12ba1PtvkJcpUyaTIUMG07p1a3P16tVE60+aNMkULVrUuLq6Gl9fX/PBBx888AZ5SQkNDTUNGjQwGTNmtLnR2Z07d8zHH39scubMadKlS2cqV65sduzYYapXr24zzWj8dLP3TyP5oOmAt23bZmrXrm29CV3JkiXNxIkTbcqcPn3atGnTxuTIkcO4urqa3Llzm4YNG5rFixdby3z22WemfPnyxsfHx6RLl84ULVrUjBgxwmaK3qQ8aPpKY+7dIM/f399kyJDBeHp6mtdee81s377dpsyjvgce9noPq+P+aTT3799vWrVqZZ5//nnj7u5usmfPbho2bGjzXnqQ+GmG4x8ZMmQwhQoVMu+8884DbyS4cuVKU7JkSeuN+EaPHm1mzpyZaMpne/vNV199ZapVq2ayZMli3N3dzQsvvGB69+5twsPDbdoTFhZmunbtavLkyWNcXV1Njhw5TK1atcz06dNtyq1YscIUK1bMuLi4PNLUs+PHjzcZMmRIcjrVGzdumCFDhpiXXnrJpEuXzmTMmNFUrlzZfPvttzZTI8fTv9wgL6Gff/7ZpEuXzuTPn98UKlTIPP/88w9tZ40aNUz27NnN3bt3H1pvwqnAk9rPhYSEmMaNG5vs2bMbFxcXky1bNvP666/b3Hgyqffso+yno6KiTO/evU2pUqWs7+tSpUrZ3Fjxjz/+MO+995554YUXjIeHh8mcObN57bXXzMaNG23amdzpZuM9ymfPg/bR8SpUqGDeeeedBz4PPAqLMalw9SQA/Itvv/1WAQEB2rNnj8qVK+fo5gD/SeHh4SpQoIDGjBmj9u3bO7o5eEocPHhQZcqU0f79+61DDoHk4BoLAADSCG9vb/Xp00eff/75I812hbRh1KhRevPNNwkVsBtnLAA8FThjAQDAs40zFgAAAADsxhkLAAAAAHbjjAUAAAAAuxEsAAAAANiNG+QlIS4uThcvXlTGjBllsVgc3RwAAADAIYwxunHjhnLlyiUnp4efkyBYJOHixYvKkyePo5sBAAAAPBXOnz+v55577qFlCBZJyJgxo6R7v0AvLy8HtwYAAABwjIiICOXJk8f6/fhhCBZJiB/+5OXlRbAAAABAmvcolwdw8TYAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACw21MRLCZPnqx8+fLJw8NDFSpU0O7dux9YdunSpSpXrpx8fHyUPn16lS5dWnPmzLEp065dO1ksFptH3bp1U3ozAAAAgDTL4dPNLlq0SIGBgZo2bZoqVKig4OBg+fv76+TJk8qePXui8pkzZ9bAgQNVtGhRubm5afXq1QoICFD27Nnl7+9vLVe3bl3NmjXL+rO7u3uqbA8AAACQFlmMMcaRDahQoYJeeeUVTZo0SZIUFxenPHny6MMPP1S/fv0eqY4yZcqoQYMGGj58uKR7ZyyuX7+u5cuXJ6tNERER8vb2Vnh4OPexAAAAQJr1ON+LHToUKjo6Wvv27ZOfn591mZOTk/z8/LRjx45/Xd8Yo5CQEJ08eVLVqlWzeW7Lli3Knj27ihQpog8++EBXr1594u0HAAAAcI9Dh0JduXJFsbGx8vX1tVnu6+urEydOPHC98PBw5c6dW1FRUXJ2dtaUKVNUu3Zt6/N169ZV06ZNlT9/fp0+fVoDBgxQvXr1tGPHDjk7OyeqLyoqSlFRUdafIyIinsDWAQAAAGmHw6+xSI6MGTPq4MGDunnzpkJCQhQYGKgCBQqoRo0akqSWLVtay5YoUUIlS5bUCy+8oC1btqhWrVqJ6gsKCtLQoUNTq/kAAADAf45Dh0JlzZpVzs7OCgsLs1keFhamHDlyPHA9JycnFSxYUKVLl9bHH3+sN998U0FBQQ8sX6BAAWXNmlW///57ks/3799f4eHh1sf58+eTt0EAAABAGuXQYOHm5qayZcsqJCTEuiwuLk4hISF69dVXH7meuLg4m6FM97tw4YKuXr2qnDlzJvm8u7u7vLy8bB4AAAAAHp3Dh0IFBgaqbdu2KleunMqXL6/g4GBFRkYqICBAktSmTRvlzp3bekYiKChI5cqV0wsvvKCoqCitWbNGc+bM0dSpUyVJN2/e1NChQ9WsWTPlyJFDp0+fVp8+fVSwYEGb6WgBAAAAPDkODxYtWrTQ5cuXNWjQIIWGhqp06dJau3at9YLuc+fOycnpfydWIiMj1aVLF124cEHp0qVT0aJFNXfuXLVo0UKS5OzsrEOHDmn27Nm6fv26cuXKpTp16mj48OHcywIAAABIIQ6/j8XTiPtYAAAAAM/QfSwAAAAA/Dc4fCgUkmYZanF0E/AUM4M50QgAAJ4unLEAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACw21MRLCZPnqx8+fLJw8NDFSpU0O7dux9YdunSpSpXrpx8fHyUPn16lS5dWnPmzLEpY4zRoEGDlDNnTqVLl05+fn46depUSm8GAAAAkGY5PFgsWrRIgYGBGjx4sPbv369SpUrJ399fly5dSrJ85syZNXDgQO3YsUOHDh1SQECAAgICtG7dOmuZMWPG6Msvv9S0adO0a9cupU+fXv7+/rpz505qbRYAAACQpliMMcaRDahQoYJeeeUVTZo0SZIUFxenPHny6MMPP1S/fv0eqY4yZcqoQYMGGj58uIwxypUrlz7++GP16tVLkhQeHi5fX199++23atmy5b/WFxERIW9vb4WHh8vLyyv5G2cHy1CLQ14XzwYz2KFvWwAAkEY8zvdih56xiI6O1r59++Tn52dd5uTkJD8/P+3YseNf1zfGKCQkRCdPnlS1atUkSWfOnFFoaKhNnd7e3qpQocID64yKilJERITNAwAAAMCjc2iwuHLlimJjY+Xr62uz3NfXV6GhoQ9cLzw8XBkyZJCbm5saNGigiRMnqnbt2pJkXe9x6gwKCpK3t7f1kSdPHns2CwAAAEhzHH6NRXJkzJhRBw8e1J49ezRixAgFBgZqy5Ytya6vf//+Cg8Ptz7Onz//5BoLAAAApAEujnzxrFmzytnZWWFhYTbLw8LClCNHjgeu5+TkpIIFC0qSSpcurePHjysoKEg1atSwrhcWFqacOXPa1Fm6dOkk63N3d5e7u7udWwMAAACkXQ49Y+Hm5qayZcsqJCTEuiwuLk4hISF69dVXH7meuLg4RUVFSZLy58+vHDly2NQZERGhXbt2PVadAAAAAB6dQ89YSFJgYKDatm2rcuXKqXz58goODlZkZKQCAgIkSW3atFHu3LkVFBQk6d71EOXKldMLL7ygqKgorVmzRnPmzNHUqVMlSRaLRT179tRnn32mQoUKKX/+/Pr000+VK1cuNWnSxFGbCQAAAPynOTxYtGjRQpcvX9agQYMUGhqq0qVLa+3atdaLr8+dOycnp/+dWImMjFSXLl104cIFpUuXTkWLFtXcuXPVokULa5k+ffooMjJSnTp10vXr11WlShWtXbtWHh4eqb59AAAAQFrg8PtYPI24jwWedtzHAgAApIZn5j4WAAAAAP4bCBYAAAAA7EawAAAAAGA3ggUAAAAAuzl8VigAzy4mGcDDMMkAAKQtnLEAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuz0VwWLy5MnKly+fPDw8VKFCBe3evfuBZb/++mtVrVpVmTJlUqZMmeTn55eofLt27WSxWGwedevWTenNAAAAANIshweLRYsWKTAwUIMHD9b+/ftVqlQp+fv769KlS0mW37Jli1q1aqXNmzdrx44dypMnj+rUqaO//vrLplzdunX1999/Wx8LFixIjc0BAAAA0iSHB4vx48erY8eOCggIULFixTRt2jR5enpq5syZSZafN2+eunTpotKlS6to0aL65ptvFBcXp5CQEJty7u7uypEjh/WRKVOm1NgcAAAAIE1yaLCIjo7Wvn375OfnZ13m5OQkPz8/7dix45HquHXrlu7evavMmTPbLN+yZYuyZ8+uIkWK6IMPPtDVq1efaNsBAAAA/I+LI1/8ypUrio2Nla+vr81yX19fnThx4pHq6Nu3r3LlymUTTurWraumTZsqf/78On36tAYMGKB69eppx44dcnZ2TlRHVFSUoqKirD9HREQkc4sAAACAtMmhwcJeo0aN0sKFC7VlyxZ5eHhYl7ds2dL6/xIlSqhkyZJ64YUXtGXLFtWqVStRPUFBQRo6dGiqtBkAAAD4L3LoUKisWbPK2dlZYWFhNsvDwsKUI0eOh647duxYjRo1SuvXr1fJkiUfWrZAgQLKmjWrfv/99ySf79+/v8LDw62P8+fPP96GAAAAAGmcQ4OFm5ubypYta3PhdfyF2K+++uoD1xszZoyGDx+utWvXqly5cv/6OhcuXNDVq1eVM2fOJJ93d3eXl5eXzQMAAADAo3P4UKjAwEC1bdtW5cqVU/ny5RUcHKzIyEgFBARIktq0aaPcuXMrKChIkjR69GgNGjRI8+fPV758+RQaGipJypAhgzJkyKCbN29q6NChatasmXLkyKHTp0+rT58+KliwoPz9/R22nQAAx7AMtTi6CXiKmcHG0U0A/jMcHixatGihy5cva9CgQQoNDVXp0qW1du1a6wXd586dk5PT/06sTJ06VdHR0XrzzTdt6hk8eLCGDBkiZ2dnHTp0SLNnz9b169eVK1cu1alTR8OHD5e7u3uqbhsAAACQVliMMUT1+0RERMjb21vh4eEOGxbFETY8zNNyhI1+ioehn+JZ8LT0U+Bp9Tjfix1+gzwAAAAAzz6CBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdkh0s5syZo8qVKytXrlw6e/asJCk4OFgrVqx4Yo0DAAAA8GxIVrCYOnWqAgMDVb9+fV2/fl2xsbGSJB8fHwUHBz/J9gEAAAB4BiQrWEycOFFff/21Bg4cKGdnZ+vycuXK6fDhw0+scQAAAACeDckKFmfOnNHLL7+caLm7u7siIyPtbhQAAACAZ0uygkX+/Pl18ODBRMvXrl2rF1980d42AQAAAHjGuCRnpcDAQHXt2lV37tyRMUa7d+/WggULFBQUpG+++eZJtxEAAADAUy5ZwaJDhw5Kly6dPvnkE926dUtvv/22cuXKpQkTJqhly5ZPuo0AAAAAnnLJChaS1Lp1a7Vu3Vq3bt3SzZs3lT179ifZLgAAAADPkGQFizNnzigmJkaFChWSp6enPD09JUmnTp2Sq6ur8uXL9yTbCAAAAOApl6yLt9u1a6ft27cnWr5r1y61a9fuseubPHmy8uXLJw8PD1WoUEG7d+9+YNmvv/5aVatWVaZMmZQpUyb5+fklKm+M0aBBg5QzZ06lS5dOfn5+OnXq1GO3CwAAAMCjSVawOHDggCpXrpxoecWKFZOcLephFi1apMDAQA0ePFj79+9XqVKl5O/vr0uXLiVZfsuWLWrVqpU2b96sHTt2KE+ePKpTp47++usva5kxY8boyy+/1LRp07Rr1y6lT59e/v7+unPnzmO1DQAAAMCjSVawsFgsunHjRqLl4eHh1rtwP6rx48erY8eOCggIULFixTRt2jR5enpq5syZSZafN2+eunTpotKlS6to0aL65ptvFBcXp5CQEEn3zlYEBwfrk08+UePGjVWyZEl99913unjxopYvX/7Y2woAAADg3yUrWFSrVk1BQUE2ISI2NlZBQUGqUqXKI9cTHR2tffv2yc/P738NcnKSn5+fduzY8Uh13Lp1S3fv3lXmzJkl3bv+IzQ01KZOb29vVahQ4YF1RkVFKSIiwuYBAAAA4NEl6+Lt0aNHq1q1aipSpIiqVq0qSfr5558VERGhTZs2PXI9V65cUWxsrHx9fW2W+/r66sSJE49UR9++fZUrVy5rkAgNDbXWcX+d8c/dLygoSEOHDn3kdgMAAACwlawzFsWKFdOhQ4fUvHlzXbp0STdu3FCbNm104sQJFS9e/Em38YFGjRqlhQsXatmyZfLw8Eh2Pf3791d4eLj1cf78+SfYSgAAAOC/L9n3sciVK5dGjhxp14tnzZpVzs7OCgsLs1keFhamHDlyPHTdsWPHatSoUdq4caNKlixpXR6/XlhYmHLmzGlTZ+nSpZOsy93dXe7u7sncCgAAAADJDhbXr1/X7t27denSJcXFxdk816ZNm0eqw83NTWXLllVISIiaNGkiSdYLsbt16/bA9caMGaMRI0Zo3bp1KleunM1z+fPnV44cORQSEmINEhEREdq1a5c++OCDR99AAAAAAI8sWcFi1apVat26tW7evCkvLy9ZLBbrcxaL5ZGDhSQFBgaqbdu2KleunMqXL6/g4GBFRkYqICBA0r2Qkjt3bgUFBUm6d33HoEGDNH/+fOXLl8963USGDBmUIUMGWSwW9ezZU5999pkKFSqk/Pnz69NPP1WuXLms4QUAAADAk5WsYPHxxx/rvffe08iRI6133U6uFi1a6PLlyxo0aJBCQ0NVunRprV271nrx9blz5+Tk9L9LQaZOnaro6Gi9+eabNvUMHjxYQ4YMkST16dNHkZGR6tSpk65fv64qVapo7dq1dl2HAQAAAODBLMYY87grpU+fXocPH1aBAgVSok0OFxERIW9vb4WHh8vLy8shbbAMtfx7IaRZZvBjv21TBP0UD0M/xbPgaemnwNPqcb4XJ2tWKH9/f+3duzdZjQMAAADw35OsoVANGjRQ7969dezYMZUoUUKurq42zzdq1OiJNA4AAADAsyFZwaJjx46SpGHDhiV6zmKx2NyRGwAAAMB/X7KCxf3TywIAAABI25J1jQUAAAAAJJTsG+RFRkbqp59+0rlz5xQdHW3zXPfu3e1uGAAAAIBnR7KCxYEDB1S/fn3dunVLkZGRypw5s65cuSJPT09lz56dYAEAAACkMckaCvXRRx/p9ddf1z///KN06dJp586dOnv2rMqWLauxY8c+6TYCAAAAeMolK1gcPHhQH3/8sZycnOTs7KyoqCjlyZNHY8aM0YABA550GwEAAAA85ZIVLFxdXeXkdG/V7Nmz69y5c5Ikb29vnT9//sm1DgAAAMAzIVnXWLz88svas2ePChUqpOrVq2vQoEG6cuWK5syZo+LFiz/pNgIAAAB4yiXrjMXIkSOVM2dOSdKIESOUKVMmffDBB7p8+bK++uqrJ9pAAAAAAE+/ZJ2xKFeunPX/2bNn19q1a59YgwAAAAA8e5J1xqJmzZq6fv16ouURERGqWbOmvW0CAAAA8IxJVrDYsmVLopviSdKdO3f0888/290oAAAAAM+WxxoKdejQIev/jx07ptDQUOvPsbGxWrt2rXLnzv3kWgcAAADgmfBYwaJ06dKyWCyyWCxJDnlKly6dJk6c+MQaBwAAAODZ8FjB4syZMzLGqECBAtq9e7eyZctmfc7NzU3Zs2eXs7PzE28kAAAAgKfbYwWLvHnz6u7du2rbtq2yZMmivHnzplS7AAAAADxDHvvibVdXVy1btiwl2gIAAADgGZWsWaEaN26s5cuXP+GmAAAAAHhWJesGeYUKFdKwYcP0yy+/qGzZskqfPr3N8927d38ijQMAAADwbEhWsJgxY4Z8fHy0b98+7du3z+Y5i8VCsAAAAADSmGQFizNnzjzpdgAAAAB4hiXrGouEjDEyxjyJtgAAAAB4RiU7WHz33XcqUaKE0qVLp3Tp0qlkyZKaM2fOk2wbAAAAgGdEsoZCjR8/Xp9++qm6deumypUrS5K2bdum999/X1euXNFHH330RBsJAAAA4OmWrGAxceJETZ06VW3atLEua9SokV566SUNGTKEYAEAAACkMckaCvX333+rUqVKiZZXqlRJf//9t92NAgAAAPBsSVawKFiwoL7//vtEyxctWqRChQrZ3SgAAAAAz5ZkDYUaOnSoWrRooa1bt1qvsfjll18UEhKSZOAAAAAA8N+WrDMWzZo1065du5Q1a1YtX75cy5cvV9asWbV792698cYbT7qNAAAAAJ5yyTpjIUlly5bV3Llzn2RbAAAAADyjkh0sYmNjtWzZMh0/flySVKxYMTVu3FguLsmuEgAAAMAzKlkp4OjRo2rUqJFCQ0NVpEgRSdLo0aOVLVs2rVq1SsWLF3+ijQQAAADwdEvWNRYdOnTQSy+9pAsXLmj//v3av3+/zp8/r5IlS6pTp05Puo0AAAAAnnLJOmNx8OBB7d27V5kyZbIuy5Qpk0aMGKFXXnnliTUOAAAAwLMhWWcsChcurLCwsETLL126pIIFC9rdKAAAAADPlmQFi6CgIHXv3l2LFy/WhQsXdOHCBS1evFg9e/bU6NGjFRERYX0AAAAA+O9L1lCohg0bSpKaN28ui8UiSTLGSJJef/11688Wi0WxsbFPop0AAAAAnmLJChabN29+0u0AAAAA8AxLVrCoXr36k24HAAAAgGdYsu9md+fOHR06dEiXLl1SXFyczXONGjWyu2EAAAAAnh3JChZr165VmzZtdOXKlUTPcV0FAAAAkPYka1aoDz/8UG+99Zb+/vtvxcXF2TwIFQAAAEDak6xgERYWpsDAQPn6+j7p9gAAAAB4BiUrWLz55pvasmXLE24KAAAAgGdVsoLFpEmTtHTpUrVr107jxo3Tl19+afN4HJMnT1a+fPnk4eGhChUqaPfu3Q8se/ToUTVr1kz58uWTxWJRcHBwojJDhgyRxWKxeRQtWvRxNxEAAADAY0jWxdsLFizQ+vXr5eHhoS1btlhvkifdu3i7e/fuj1TPokWLFBgYqGnTpqlChQoKDg6Wv7+/Tp48qezZsycqf+vWLRUoUEBvvfWWPvroowfW+9JLL2njxo3Wn11ckj35FQAAAIBHkKxv3AMHDtTQoUPVr18/OTkl66SHJGn8+PHq2LGjAgICJEnTpk3T//3f/2nmzJnq169fovKvvPKKXnnlFUlK8vl4Li4uypEjR7LbBQAAAODxJCsVREdHq0WLFnaFiujoaO3bt09+fn7/a4yTk/z8/LRjx45k1ytJp06dUq5cuVSgQAG1bt1a586ds6s+AAAAAA+XrGTQtm1bLVq0yK4XvnLlimJjYxPNLOXr66vQ0NBk11uhQgV9++23Wrt2raZOnaozZ86oatWqunHjxgPXiYqKUkREhM0DAAAAwKNL1lCo2NhYjRkzRuvWrVPJkiXl6upq8/z48eOfSOOSo169etb/lyxZUhUqVFDevHn1/fffq3379kmuExQUpKFDh6ZWEwEAAID/nGQFi8OHD+vll1+WJB05ciRZL5w1a1Y5OzsrLCzMZnlYWNgTvT7Cx8dHhQsX1u+///7AMv3791dgYKD154iICOXJk+eJtQEAAAD4r0tWsNi8ebPdL+zm5qayZcsqJCRETZo0kSTFxcUpJCRE3bp1s7v+eDdv3tTp06f17rvvPrCMu7u73N3dn9hrAgAAAGnNYwWLpk2b/msZi8WiJUuWPFJ9gYGBatu2rcqVK6fy5csrODhYkZGR1lmi2rRpo9y5cysoKEjSvQu+jx07Zv3/X3/9pYMHDypDhgwqWLCgJKlXr156/fXXlTdvXl28eFGDBw+Ws7OzWrVq9TibCgAAAOAxPFaw8Pb2fqIv3qJFC12+fFmDBg1SaGioSpcurbVr11ov6D537pzNzFMXL160DsGSpLFjx2rs2LGqXr269U7gFy5cUKtWrXT16lVly5ZNVapU0c6dO5UtW7Yn2nYAAAAA/2MxxhhHN+JpExERIW9vb4WHh8vLy8shbbAMtfx7IaRZZvDT8baln+Jh6Kd4Fjwt/RR4Wj3O9+Lk34gCAAAAAP4/ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN1cHN0AAACAtM4y1OLoJuApZgYbRzfhkXDGAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALCbw4PF5MmTlS9fPnl4eKhChQravXv3A8sePXpUzZo1U758+WSxWBQcHGx3nQAAAADs59BgsWjRIgUGBmrw4MHav3+/SpUqJX9/f126dCnJ8rdu3VKBAgU0atQo5ciR44nUCQAAAMB+Dg0W48ePV8eOHRUQEKBixYpp2rRp8vT01MyZM5Ms/8orr+jzzz9Xy5Yt5e7u/kTqBAAAAGA/hwWL6Oho7du3T35+fv9rjJOT/Pz8tGPHjlStMyoqShERETYPAAAAAI/OYcHiypUrio2Nla+vr81yX19fhYaGpmqdQUFB8vb2tj7y5MmTrNcHAAAA0iqHX7z9NOjfv7/Cw8Otj/Pnzzu6SQAAAMAzxcVRL5w1a1Y5OzsrLCzMZnlYWNgDL8xOqTrd3d0feM0GAAAAgH/nsDMWbm5uKlu2rEJCQqzL4uLiFBISoldfffWpqRMAAADAv3PYGQtJCgwMVNu2bVWuXDmVL19ewcHBioyMVEBAgCSpTZs2yp07t4KCgiTduzj72LFj1v//9ddfOnjwoDJkyKCCBQs+Up0AAAAAnjyHBosWLVro8uXLGjRokEJDQ1W6dGmtXbvWevH1uXPn5OT0v5MqFy9e1Msvv2z9eezYsRo7dqyqV6+uLVu2PFKdAAAAAJ48izHGOLoRT5uIiAh5e3srPDxcXl5eDmmDZajFIa+LZ4MZ/HS8bemneBj6KZ4F9FM8CxzZTx/nezGzQgEAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHZ7KoLF5MmTlS9fPnl4eKhChQravXv3Q8v/8MMPKlq0qDw8PFSiRAmtWbPG5vl27drJYrHYPOrWrZuSmwAAAACkaQ4PFosWLVJgYKAGDx6s/fv3q1SpUvL399elS5eSLL99+3a1atVK7du314EDB9SkSRM1adJER44csSlXt25d/f3339bHggULUmNzAAAAgDTJ4cFi/Pjx6tixowICAlSsWDFNmzZNnp6emjlzZpLlJ0yYoLp166p379568cUXNXz4cJUpU0aTJk2yKefu7q4cOXJYH5kyZUqNzQEAAADSJIcGi+joaO3bt09+fn7WZU5OTvLz89OOHTuSXGfHjh025SXJ398/UfktW7Yoe/bsKlKkiD744ANdvXr1ge2IiopSRESEzQMAAADAo3NosLhy5YpiY2Pl6+trs9zX11ehoaFJrhMaGvqv5evWravvvvtOISEhGj16tH766SfVq1dPsbGxSdYZFBQkb29v6yNPnjx2bhkAAACQtrg4ugEpoWXLltb/lyhRQiVLltQLL7ygLVu2qFatWonK9+/fX4GBgdafIyIiCBcAAADAY3DoGYusWbPK2dlZYWFhNsvDwsKUI0eOJNfJkSPHY5WXpAIFCihr1qz6/fffk3ze3d1dXl5eNg8AAAAAj86hwcLNzU1ly5ZVSEiIdVlcXJxCQkL06quvJrnOq6++alNekjZs2PDA8pJ04cIFXb16VTlz5nwyDQcAAABgw+GzQgUGBurrr7/W7Nmzdfz4cX3wwQeKjIxUQECAJKlNmzbq37+/tXyPHj20du1ajRs3TidOnNCQIUO0d+9edevWTZJ08+ZN9e7dWzt37tSff/6pkJAQNW7cWAULFpS/v79DthEAAAD4r3P4NRYtWrTQ5cuXNWjQIIWGhqp06dJau3at9QLtc+fOycnpf/mnUqVKmj9/vj755BMNGDBAhQoV0vLly1W8eHFJkrOzsw4dOqTZs2fr+vXrypUrl+rUqaPhw4fL3d3dIdsIAAAA/NdZjDHG0Y142kRERMjb21vh4eEOu97CMtTikNfFs8EMfjretvRTPAz9FM8C+imeBY7sp4/zvdjhQ6EAAAAAPPsIFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHYjWAAAAACwG8ECAAAAgN0IFgAAAADsRrAAAAAAYDeCBQAAAAC7ESwAAAAA2I1gAQAAAMBuBAsAAAAAdiNYAAAAALAbwQIAAACA3QgWAAAAAOxGsAAAAABgN4IFAAAAALsRLAAAAADYjWABAAAAwG4ECwAAAAB2I1gAAAAAsBvBAgAAAIDdCBYAAAAA7EawAAAAAGA3ggUAAAAAuxEsAAAAANiNYAEAAADAbgQLAAAAAHZ7KoLF5MmTlS9fPnl4eKhChQravXv3Q8v/8MMPKlq0qDw8PFSiRAmtWbPG5nljjAYNGqScOXMqXbp08vPz06lTp1JyEwAAAIA0zeHBYtGiRQoMDNTgwYO1f/9+lSpVSv7+/rp06VKS5bdv365WrVqpffv2OnDggJo0aaImTZroyJEj1jJjxozRl19+qWnTpmnXrl1Knz69/P39defOndTaLAAAACBNcXiwGD9+vDp27KiAgAAVK1ZM06ZNk6enp2bOnJlk+QkTJqhu3brq3bu3XnzxRQ0fPlxlypTRpEmTJN07WxEcHKxPPvlEjRs3VsmSJfXdd9/p4sWLWr58eSpuGQAAAJB2ODRYREdHa9++ffLz87Muc3Jykp+fn3bs2JHkOjt27LApL0n+/v7W8mfOnFFoaKhNGW9vb1WoUOGBdQIAAACwj4sjX/zKlSuKjY2Vr6+vzXJfX1+dOHEiyXVCQ0OTLB8aGmp9Pn7Zg8rcLyoqSlFRUdafw8PDJUkRERGPsTVPGKO28BAO7ZsJ0U/xEPRTPAvop3gWOLKfxr+2MeZfyzo0WDwtgoKCNHTo0ETL8+TJ44DWAP/Oe5S3o5sA/Cv6KZ4F9FM8C56Gfnrjxg15ez+8HQ4NFlmzZpWzs7PCwsJsloeFhSlHjhxJrpMjR46Hlo//NywsTDlz5rQpU7p06STr7N+/vwIDA60/x8XF6dq1a8qSJYssFstjbxeerIiICOXJk0fnz5+Xl5eXo5sDJIl+imcB/RTPAvrp08UYoxs3bihXrlz/WtahwcLNzU1ly5ZVSEiImjRpIunel/qQkBB169YtyXVeffVVhYSEqGfPntZlGzZs0KuvvipJyp8/v3LkyKGQkBBrkIiIiNCuXbv0wQcfJFmnu7u73N3dbZb5+PjYtW148ry8vNjB4KlHP8WzgH6KZwH99Onxb2cq4jl8KFRgYKDatm2rcuXKqXz58goODlZkZKQCAgIkSW3atFHu3LkVFBQkSerRo4eqV6+ucePGqUGDBlq4cKH27t2r6dOnS5IsFot69uypzz77TIUKFVL+/Pn16aefKleuXNbwAgAAAODJcniwaNGihS5fvqxBgwYpNDRUpUuX1tq1a60XX587d05OTv+bvKpSpUqaP3++PvnkEw0YMECFChXS8uXLVbx4cWuZPn36KDIyUp06ddL169dVpUoVrV27Vh4eHqm+fQAAAEBaYDGPcok34EBRUVEKCgpS//79Ew1ZA54W9FM8C+ineBbQT59dBAsAAAAAdnP4nbcBAAAAPPsIFgAAAADsRrAAAAAAYDeCBRyKS3zwLKCfAoD94uLiHN0EpDCCBVJd7969tXnzZh07dow7m+OptXTpUh08eFCS6Kd4av3f//2fNm/ebLOML2942oSEhOjGjRs2tw/AfxN/YaSquLg4hYaGatasWapWrZqCgoK0d+9eRzcLsHHixAkNHz5cH330kSpWrKg1a9bo77//dnSzABtbt27VvHnz1Lx5c7377ruaMmWKJMnJyYmzbHhqLFq0SKNGjVKJEiU0cuRIbd261dFNQgpiulk4xK1bt7Ry5UqNHDlSOXPmVKNGjdS1a1dHNwuQMUYWi0W3bt1SdHS0unbtqnPnzsnHx0cjRoxQyZIlHd1EwMbp06cVHBys3bt3y8XFRStXrlSWLFkc3SxAknT37l25urpq2rRp2rlzp1auXKnevXvro48+4sbF/0EEC6Sq+C9t8f8ePXpUU6dO1bZt2/TWW29p4MCBjm4ikMjSpUs1Z84cHTp0SIsWLVK5cuUc3SSkcfH70Li4ODk5OenWrVs6fPiwunbtqoiICK1atUpFihSxPg84QvxXzPjhpJcvX9bq1avVqVMntW3bViNGjJCvr68jm4gnjGCBVBH/IRgvLi5OFotFFotF58+f11dffaV169apZ8+eat26tQNbirTs/n4aExMjFxcXSdK+ffs0evRoHTlyREuXLlXRokUd1UykcfcfoEnYby9fvqy33npLoaGh+vXXX+Xu7p6oXwOpIWG/i42NlbOzs/W5LVu2qG7dumrfvr0mT57sqCYiBXAYAykuPkRI0sWLF3X58mU5OTlZl+XJk0cdO3ZUoUKF9H//93+6evWqI5uLNCphP/3nn38kyRoqJKls2bIKDAxUgQIFNGXKFN28edMh7UTalrCf3rhxQ5Jsvrxly5ZN8+bNk4eHh9q0aWPzPJBaEvZTSdZQYYxRTEyMatSooZUrV2ratGmaNWuWo5qJFECwQIqLPw0/YMAA1a9fX8WLF9eoUaN05swZa5m8efOqe/fuWrNmjdauXeuopiINi++nI0aMUNOmTeXn56eVK1cqIiLCWqZixYqqU6eOfvrpJ127dk0SU9EidSXsp3Xq1FGzZs00depUSfe+vMXFxSlXrlwaMGCALl26pJ07d0qinyJ1xffT4OBgvfPOO+rVq5d27doli8UiJycnxcbGqk6dOho2bJgmTZqk3377zcEtxpNCsECq+P7777VgwQJ9/PHH6tq1qz7//HMFBQXp6NGj1jIVK1bU4MGDNXv2bJsvc0BqmT59uiZMmKBGjRopOjpagwYN0oQJE6xnMCSpe/fuypQpk4YMGSKJo8FIfdOnT9fEiRP1xhtvKDo6WjNmzFDPnj0lyXo22M/PT9HR0Vq+fLkk+ilSX1BQkIKCghQbG6udO3fqrbfe0o8//ignJydr8GjYsKEyZMigP/74QxIB+L+AYIEUcf886p6enurRo4feffddDRo0SLNmzdK6desUHBysY8eOWcu9/PLLunXrlmJjY1O7yUiD7u+nERER+vzzz/XRRx9p69at8vPz04oVKzRx4kSbcPHxxx8rKipK0dHRqd1kpEH399PIyEhNmDBBffv21ezZs9WiRQuFhISoR48e1jKZM2fW0KFDtX37doWGhqZ2k5EGJbU/Xbx4sRYsWKCvv/5adevWVatWrbRmzRpr0C1VqpRefvlljRs3ThIB+L+AYIEnzhhjPRrxzTffqFevXpowYYKioqKsZRo1aqSJEydq/fr1mjBhgvVGZDVq1FCjRo109uxZRzQdaUjCfrp48WLNmjVLR44cUebMma1lxo4dq9dee02rVq3SpEmTrNf/lCxZUhkyZOB6IKS4hP100aJFWrRokUJCQqzLMmfOrPbt26tt27bavHmzPvroI+u6BQoUUJ06dZQuXTqHtB1pR8LZx7Zu3apt27Zp27Zt1jMQL774ovr27avmzZvrnXfe0Y8//mhdt2PHjvLz89Pt27cd0nY8YQZ4guLi4qz/Hzx4sPHw8DD169c3Tk5OpkyZMmbr1q025VetWmVcXV3NqFGjTExMjDHGmNu3b6dqm5H2JOyngYGBxsfHx+TLl89YLBZTt25dc+3aNZvyffr0MXny5DEzZswwsbGxxhhjLl++nKptRtqTsJ/26tXLZMiQweTLl8+kT5/evPHGGzZlr127ZsaNG2eyZ89uvvjiC+vyM2fOpFJrgXv7ynTp0pkiRYoYDw8P880339g8f/r0afP+++8bi8Vitm/fbowxJjo62vz666+OaC5SgMu/Rw/g0cWfxtyzZ49CQ0O1ceNGVa5cWRs2bNAnn3yiKVOmyMnJSZUrV5Z0b3zl5s2bVbFiReusEdwwByktvp/+/vvvunDhgkJCQvTCCy9o6tSpWrZsmQYOHKgRI0YoU6ZMkqTRo0fr+eefV9u2ba1H5bJmzSop8RS1wJMS36+uXr2qI0eO6JdffpG3t7dCQkLUv39/tWvXTt9++60kKVOmTGrbtq1y5syp5s2bW+vIly+fA1qOtCLh/u/gwYNau3atNm/erNu3b2vJkiXq3LmzsmbNqsaNG0u6dxbto48+Uv78+fXKK69IklxdXbnx6H8I97HAE7dkyRJ99tlncnJy0o8//qjs2bNLktasWaOhQ4cqf/786t69uypVqmSz3v3zXAMpae7cuRo1apRy586tJUuWKEOGDIqLi9PYsWO1bNkylS5dWkFBQfLx8bFZj36K1DRu3Dh99913KlCggGbOnKlMmTIpMjJSy5YtU9++fVWnTp0kp+uknyI1jR49WhcuXJCTk5MmTJggSbp+/bqGDh2qiRMnasmSJdZwkVDCewXhv4FrLGC3+y/Yypgxo7Jly6bffvtNu3btsi6vX7++hgwZovPnz2vw4ME6fPiwzXp8CCIlJeynxhjdunVLHh4eOnr0qNzc3CTdm1GnV69eatq0qY4cOaL333/feq+AePRTpKT796dFihRRRESE9u3bZ+176dOn1xtvvKExY8YoJCQkyS9s9FOkpPuPSV++fFmTJ0/WwYMHdevWLUmSj4+PhgwZou7du6tFixZauHBhonoIFf89BAvYJeEFWz/++KPOnDljnZu6SpUqGjt2rNatW2ctX69ePfXq1Uv58+fXSy+95KhmI41J2E/379+vGzduqEOHDurVq5fSp0+vpk2bWgOEk5OTPv74Y7322mvy9vZW+vTpHdl0pCEJ++nevXt18eJFNWzYUF9//bXu3Lmj9u3bW8umT59eTZo00aeffmpdF0gNCW9+d/LkSRljNHbsWI0aNUrbtm3T/PnzrWW9vb01ePBgvf3225oyZYqjmozU5MDrO/CMS3hhYd++fc3zzz9vpk+fbm7evGmMMWbz5s2mUaNGpmbNmmbdunVJ1hF/ISyQUhL20wEDBphSpUqZ77//3sTExJi7d++a7777zlSsWNE0btzY3Lhxw2a9+HXpp0hpCftpv379TIUKFcyMGTPM7du3TWxsrFm3bp3JnDmzadGihc16CSe7oJ8ipSXsY4MHDzb+/v5m4cKFNstcXFzMzJkzbda7efMm/TONIFjAbmPHjjXZs2c3O3fuNOHh4TbPxYeL2rVrmxUrVjiohYAxw4cPN9mzZzfr16+3mfXp7t27Zvbs2ebVV181b7zxhrl+/brNegm/8AEpbfjw4SZr1qwmJCTEpi/GxcWZdevWmSxZsphWrVo5sIWAMZ988onJkiWLWbt2rbl48aLNc4MHDzaurq7m22+/TbQe4eK/j6FQeCzm/4+rjP/37t27+umnn9S9e3dVqFBBXl5ekmS9wV2NGjXUq1cvRUZGKiQkxDGNRppz9+5d6/+NMbp8+bJWrlyp0aNHq3bt2tbZnuIvHHz77bfVrVs3/frrrwoKCrKpixmfkFISzttvjNHFixe1evVqffnll6pZs6a8vb0l/W/oSZ06dbRgwQItXLhQgwcPdlSzkcYdO3ZMK1eu1Ny5c+Xv76+cOXNK+t9wvCFDhmjAgAEKCAjQmjVrbNaNH+qH/y6umsEj69SpkzJnzqxRo0ZZv2zdvHlTe/fulb+/v6T/TT3n7OysO3fu6NKlS6pataomTZqkUqVKObL5SCO6du2qN998U6+99pq1P96+fVtnzpxR/vz5Jf1vLLuLi4vu3LmjyMhItWjRQlmyZJGfn5+DtwBpwdixY1W0aFE1bNjQ2h8tFosuXLhgvaFdfP91cnLSnTt3dP36ddWuXVs7d+5UmTJlHLwFSAtGjhypGjVq2MziePv2bf311182NxOV7oWGqKgoubm5aciQIcqdO7fq1KmT2k2GgxEd8cjq1q2rv//+W5GRkdYjE5kyZVLVqlW1cuVKhYaGymKxWJ87dOiQgoODdeXKFb388stycnLiAkOkOGOMFixYYHOBoa+vrzw9Pa1Hz5ycnKxn1fbt26f58+crLi5O/v7+cnZ2tj4HpJQ9e/Zo6dKlkmyP4sbGxuq3336TZHtB9uHDhzV79myFh4erfPnycnFxUUxMTOo2GmnK1atXtXHjRl29elXS//pjVFSUXFxcFBUVJUk2+8tNmzZp5syZMsaoY8eO9NM0iGCBR+br66tNmzbp8OHDNl/MateurStXrmjcuHG6evWqnJycdOPGDQ0fPlxHjhyxOarBaVCklPjhea+99pr+/PNPRURESJKio6Pl5uamDh06aN26dZo4caKke9NxxsTEaPjw4dq2bZvNtIdM1YmUEt9PP/74Y509e1YHDhyQdO9LW86cOfXxxx9rwIABWrx4sbUfRkVF6dNPP9Xhw4etw00lpupEysqSJYvq1q2rUaNGKSwszPr5XalSJb300kvq3LmzwsLCrP309u3bmjx5so4ePWozhJR+mrZwgzw8li5dumjHjh1at26d9cZ3kjRixAitWrVKYWFhKly4sC5duqTY2Fjt27dPrq6uNtMoAinp7t27evHFF1W7dm1NnTrVuvz06dP64osvtHbtWhUrVky5c+fWoUOHFBERof3798vV1ZW7aCPVnDt3Tk2bNlXDhg01ZMgQ6z4yNDRUn3/+ub744gu98847cnJy0p9//qmrV6/ST5Hq9u/fr169eqlr165q1qyZ9caLp0+fVqtWrfT333+rW7duslgsWrduncLCwnTw4EHCRBpGsMAjif8g27Vrl/r3769SpUpp8ODBNncl3rZtm3bs2KGLFy8qb9686tatm/U0KDsZpIb4D73Vq1erR48e+vjjj9WlSxfr83///be2b9+ub775Rj4+PsqVK5dGjx5NP4VD/PDDD2rZsqWWL1+u119/3bo8Ojpaq1at0vz58+Xq6qo8efIoKCiIfgqHaNOmjXbv3q3NmzdbL9SW7p2h6N69u06cOKG4uDgVLlxY06dPl6urK3d+T8MIFnhsQUFBWrFiherWrasePXpYZ9hJCjsXOEJYWJhGjRqlHTt2qEuXLmrTps1Dy9NPkdriD9Z89NFH+uqrr7Ry5cpEEwfc3y/pp0hN8WfRYmJiVK5cOXl6eiokJMQ6uUC8yMhIOTs7y8PDQ5IIv2kcY1PwyOIzaP/+/VWtWjWtX79ePXv21Pnz523KJbzgkA9BOIKvr686dOigokWLauLEiRozZozN8/dfTEg/RWqLH8oUGBio1q1bq0GDBpozZ46io6OtZe6f7IJ+itQUP+GKi4uL5s+fr6tXr6patWo6fvy4tZ/GxcXJ09PTGiqMMYSKNI4zFngsCa+VmD59ulauXKldu3Zp8uTJypcvn8qXL+/gFgL/c/LkSX3//feaOHGiqlSpol69eqlEiRLKmDGjo5sGWIWFhWn69OkaPny4OnfurKpVq6p58+aObhZg448//tC7776rq1evqn379nrrrbeUL18+RzcLTxmCBWw8ykXWCctcv35dU6dO1bZt2/Tnn38qMDBQrVq1kqenZ2o0F2nU/RevPuxi1qioKP3555/q0aOHnJ2d9eeff2rWrFkqUaJEolP6wJOUVL98WF/dtGmTFi5cqN27dytnzpwKDAxU9erV5ebmlhrNRRr1uJMBDBkyRMePH9eWLVvUtWtX1a1bl4OKsCJYIEmnTp2SMUaFCxe2Lku487l/RxQeHq5//vlHV69eVdmyZVO9vUg77t69K1dXV0nSxYsXlTlzZrm7u//rB2NsbKwiIiIUEhKiwoULq2TJkqnRXKRRUVFRcnd3lySFhobKx8dHbm5u1qm67x/WFL9PjYqKUkxMjFauXKkyZcqoSJEijmg+0oiE+9O7d+/KYrFYhzLdf6AxYb+Njo7W+vXrFRYWphIlShAsYEWwgL744gtVrFhRr776qiSpT58+WrFihc6fP6/mzZurQ4cOqlKliqQHHylm+kOktLlz56p69erKkyePJGnw4MFas2aNbty4oU6dOumNN96w3ln7fvRPpJZJkyapa9eu1v42dOhQ/fDDD8qYMaNeffVVjRw5Uh4eHg+8EJupuZEatm7dqmrVqll/HjNmjDZt2iQvLy81adJEb7/9tqTE/ZF9Kf4Ne6807vjx4/rkk080ceJEHTp0SEuXLtWSJUs0atQozZw5U3v27NGoUaO0bt06SbKGiHjxOxh2NEhJP/zwg/r166cpU6bo+vXrWrhwoaZOnaoPP/xQlSpV0vz58zV8+HCdPHkyyfXpn0gNa9euVVBQkNq3by/pXr+dNGmSAgMDVaZMGW3fvl1NmjTR7du3H3iHd0IFUtrs2bNVo0YNzZs3T9K9mR4///xzvfjii4qJiVHnzp01duxYSf+7gDse+1L8G85YQNu2bVO7du1Us2ZNZc+eXc8995zef/99SdLRo0fVoUMHZcqUST169JC/v7+DW4u0avjw4db5/sPDw1WxYkW1aNFC0r2JBGbPnq3ChQurf//+Kly4MEfWkOpu3rypOXPm6JtvvlGJEiVUrFgx5cmTR61atVJsbKyWL1+uUaNGKVOmTFqxYoXSpUvH1JxIdWfPntXkyZM1ffp0TZgwQdeuXVOpUqVUs2ZNXbt2TTNmzFDfvn01ZswY9erVSxJn0vAYDNKkuLg4Ex0dbf15x44dJn/+/MbJycn079/fpuyRI0dMxYoVTcOGDc3y5ctTu6lI4+7cuWP9/4gRI8zLL79sfH19zcKFC23KTZ8+3VSqVMm899575siRI6ndTKRxd+/eNcYYExERYaZOnWrKli1rMmXKZJYtW2YtEx0dbZYsWWJeeeUVU7duXRMZGemg1iItiouLM3FxccYYY/7880/z0UcfGS8vL5MzZ06zc+dOa7nw8HDz+eefGycnJzN27FhHNRfPKOJnGnXlyhXrBVvff/+9ihcvrh9++EH58uXTjh07tHv3bmvZl156STNmzNCxY8f0888/O6rJSINiY2OtF8D+8ssvGjBggFq3bi1jjJYvX66LFy9ay3bs2FEBAQH6+eeftXz5cge1GGnRjRs3rGcdjhw5ovfff1/t27dXhgwZ9M0331jLubq66vXXX1f//v117NgxDRw40FFNRhp0584d61lcLy8vBQUFqVu3brp8+bIOHjxoLefl5aXOnTvr888/V+/evTV//nwHtRjPJEcnG6S+7du3mwwZMpgTJ06YPn36mFy5cpmzZ88aY4z55ZdfTP78+U2rVq3M3r17bdb7448/TExMjCOajDRo5cqVpnr16sYYY3r27GmKFStmIiIijDHGjBw50pQqVcr069fPXLx40Wa9FStW0E+RahYvXmyaNm1qbt++bXr27Gl8fHzMjRs3zM2bN83UqVNNiRIlTLt27WzWiY6ONlu2bKGfItWsWrXKjB492hhjTKdOnUz+/PlNbGysOXv2rPnoo4+Mh4eHmTNnjs06169fN/Pnz7eejQMeBddYpEEnTpzQiBEjtGrVKjk5Oeno0aPKmTOndazvzz//rLZt26pixYrq1auXypQpY7P+g2YzAZ6kHTt2qEmTJvLx8VFYWJh27typokWLWp8fNmyYli9fLn9/f3Xv3l05c+a0WZ9+itSwb98+vfLKKypWrJguXLigrVu3WqcyjoyM1OzZs/X111/r5Zdf1syZMxOtTz9FaggMDNT8+fNVtGhRHT16VJs3b1bx4sUlSRcuXFBwcLCmT5+uKVOm6J133km0PtcC4VExFCoNic+QRYsWVcGCBRURESGLxaLLly9by8TGxqpq1aqaPXu29uzZo/79++u3336zqYcPQaSUli1basGCBZKkV199VX5+fjp16pReeukla6i4e/euJGnQoEF64403tHHjRg0fPlxXr161qYt+ipQWGxursmXLqnXr1jp27JheffVV63TIkpQ+fXq1bdtWHTt21KFDh9SkSZNEddBPkVJGjhypZcuWSZLGjx+vF154QVu3blWbNm1UsGBBa7nnnntOPXv2VOfOnfXhhx9q+vTpieoiVOBRESzSkIQz5DRt2lQ//vijGjZsqFq1amnHjh1ycXGxTn9YtWpVzZo1S15eXjY7ICAlubq6qkOHDtZrJN566y3Nnj1bFy5cUO3ata1l7ty5I0n69NNPVbduXd28eVOZM2d2VLORxsQfpIkPBf7+/po7d65++uknvf/++zp37py1XHy4aN26tTJmzGgzdSeQUk6dOqW5c+dq1qxZWrVqlSSpVKlSateunZYuXaqJEydaDyoaY/Tcc8+pR48eatq0qX744QdHNh3POkeOw0LqiI2Ntf5/3LhxJiAgwPrz4cOHTcuWLU3WrFnNrl27rMsnTZpkHc9+fx1ASoifreTDDz807u7uNrPpbNu2zTz33HOmdu3aNuusWrXKZt34f4GUkrCPffXVV+brr782N2/eNMYYs3PnTpMuXTrTvHlzc/78eWu5NWvW2KzL/hSpYdeuXaZ69erm9ddfN9u2bbMu79Wrl3n++efN559/bi5fvmxdHhYWZoyhf8I+BIv/uIQ7iG3btpnevXsbi8Vi+vTpY11+5MgR06pVK+Pl5WW++uor4+fnZ0qWLMnOBakm4UWsFy5cMA0aNDDZs2c3K1eutC7/5ZdfTJ48eUz16tXNzp07Te3atU21atUIFUg1CfeJ586dM8WLFzclSpQws2fPth6I2bVrl/H09DTNmjUzK1euNK+//ropXLgw/RSpJuHF1itWrDAVK1Y09evXN2vXrrUu7927t8mfP7/57LPPzKFDh0zNmjXNK6+8Yn2ez38kFxdvpxF9+vTR6tWr5efnp71792rXrl3q1KmTpk6dKkn6/fff9eWXX2rDhg0qVKiQlixZIldXV26Kg1TVp08fbd26VVmyZNHu3bt1584dfffdd3rjjTckSQcPHtTbb7+tuLg4Zc2aVZs3b5arqys3w0OqCgwM1MmTJ3Xnzh399ttvio6O1pgxY/TGG2/Iy8tLe/fuVatWreTl5SUPDw9t2bKFfopUN2DAAF28eFE7d+7U77//ripVqqhPnz6qX7++JOmTTz7RDz/8oNjYWGXNmlVbt26Vm5ubg1uNZ55jcw1Sw4YNG4yXl5fZunWrMebeFHKzZs0y6dKlM126dLEpe+nSJesRNaaYQ2qaO3euyZAhg9m9e7e5fv26+fPPP817771n0qVLZzMs6u7du+bgwYPWI2r0U6SmOXPmGB8fH/Prr7+af/75x8TGxppGjRqZ/Pnzm2+//daEh4cbY4wJDQ01v/32G/0UqSbh2bApU6YYb29vs337dnPmzBkTEhJiSpcuberXr29+/PFHa7mdO3earVu3Ws8a009hLy7zTwMuXbqkrFmzqnz58pIkb29vtWzZUhEREerZs6e8vb01cuRISVKWLFlksVgUFxfHLBBIMZ999pk6deqk7NmzW5ddunRJZcuW1SuvvCLpXj+dOnWqbt++rffee0/u7u6qW7euXFxcVKpUKUminyLV/f333ypcuLAKFSokNzc3OTk5acWKFfL391f//v0l3Zscw9fXV76+vpLop0hZU6dOVadOnWxmGNu/f7/8/Pz06quvSpLy5cunSZMmqXXr1goKCpIk1a1bVxUqVLCuExsbSz+F3Rjj8h9jkhjZVrhwYV2+fFlbtmyxLvPw8NBrr70mHx8fjRo1Sh999JEkWYc9MfwJKeXQoUNavnx5olmcLBaLDh48qKioKEn35k13c3PT22+/revXr6tBgwbaunWrzTr0U6SW+NmcoqOjdfXqVaVLl07Ozs66deuWJGnEiBG6evWqvvzyS23cuFHS//bH9FOklOnTp+uXX36xWWaMkaenp27fvi3pXt+Ni4tT5cqV1a9fP+3bt08jRoxItB5TH+NJYG/3HxIXF2cdvxs/178kPf/886pZs6amTZumn3/+2brcx8dHTZo00TfffKN58+ZpzZo1qd5mpC1xcXEqWbKk9uzZIxcXF61cuVJnz56VJDVr1kwFCxZU586ddf36deuRs+zZs6tbt2764osvVLlyZUc2H2nI/dPCxoeD9u3b6/r16woICJAkeXp6SpKioqLUrl07Zc2aVQMHDlR0dDTXUyDFvfvuu5o9e7acnZ21adMm3b17VxaLRVWrVtWPP/6opUuXysnJydp/3d3dVbFiRZUrV856NgN4kggW/xHGGOuOY9y4cXrvvffUtGlTHT58WNmzZ1ePHj10/fp1DRo0SBMnTtTGjRvVvn17Xb58WbVq1VK6dOl05swZB28F/uvij+DGxsbq3LlzatKkiQYMGKC///5bzz33nNq3b6/ff/9dAQEBOnbsmA4cOKChQ4fq8uXL6tGjh1xcXBQTE+PgrcB/XcL96YwZM9StWzdNnjxZBw8eVI4cOfTVV19p+fLlatGihQ4dOqRff/1VI0aMkJeXl+bPn6/ffvtNK1ascPBW4L8uJibGeubsp59+UufOndWvXz9FR0frzTffVM+ePfX222/ru+++0++//65r165p2bJlql+/vsaPHy8nJyfuq4Inz5EXeODJSDgt3MiRI42Xl5fp1q2bKV68uMmWLZtZsGCBMebedJ1du3Y1GTJkMMWKFTOVK1c20dHRxhhjypcvb2bOnOmQ9iPt+euvv4wxxmzatMl4enqa1q1bm2vXrpmYmBgze/ZsU7VqVePk5GQKFChgypYta+2nQEpLeAHsJ598YjJnzmzq1KljChUqZGrWrGk2btxojLk3KUbBggWNr6+vyZUrlylXrpy5c+eOuXjxoilYsKD55ZdfHLUJSGOuXbtmbt26Zfr162cqVapkevfubb0I+5NPPjGenp7m+eefN/ny5TPFihWz7k+Z+hgpgWDxH3L27FnToUMH8/PPP1uXvfvuuyZHjhxm3rx51mVhYWHWG+EY87+b5fz555+p2l6kTatXrzYuLi7m9OnTxhhjfvrpJ+Pm5mZat25trl69ai23fft2c+jQIWYrgUMcOHDAdOjQwezYscMYY8yWLVvMm2++acqXL2/Wr19vjDEmOjrabN++3Rw4cMB6gGfAgAGmaNGi5sKFCw5rO9KO6dOnm7ffftsYY0x4eLjp37+/KV++vOnbt681QOzYscP83//9n/n+++/ZnyLFESz+I7777jvj7OxsXnzxRbNv3z6b5959912TK1cuM2/ePOtUiMYY8/PPP5uAgADj6+tr9u/fn9pNRhoR/4Ur/ujYn3/+aerVq2f69Olj7Y8///yzcXNzM++++645d+5cojoS3kAPSGnff/+9KVeunKlUqZJN2P3555/NW2+9ZSpWrGhWr15ts87hw4dN+/btTaZMmcyBAwdSucVIK+4/y/B///d/xmKxmKVLlxpj7oWLAQMGmPLly5vevXsnebaX/SlSEtdY/Ee8++67qlevnk6cOKHjx4/bjEP/7rvvVKdOHb377rvauXOndXnJkiVVqlQp/fzzz3r55Zcd0WykAfFj1U+ePClJyps3r+rUqaNNmzbpjz/+kCRVqVJFmzZt0uLFi9W1a1ddvnzZpg5mK0FqiomJkbu7u44dO6ZTp05Zl1epUkU9evRQvnz51L17d+3atcv63J07d/T8889r27ZtKl26tANajbQgfkKAf/75RzExMapfv7769eunoUOH6ujRo/Ly8lK/fv1Uu3Zt/fLLL+revbtiY2Nt6mB/ipTEnbefQfffDdskuJtrrVq1dOLECc2ZM0fVq1e32YF89tln6t+/v5ydna11GO4Ei1QwefJkffjhhwoKCtJbb72lAgUKqHbt2oqNjdWmTZus5TZt2qRhw4Zp06ZNTNGJVHH//jTe2rVrNXz4cGXIkEHDhw+33gdIutdPt2zZosGDB9vsY+/evStXV9dUaTfSrrFjx2ru3Lnq2rWrWrZsqevXr6tDhw6qVauWPvzwQ6VLl043b97UgAEDdOfOHX311Vd8ziPVECyeMQk/BOfMmaMDBw7IyclJJUqUUNu2bSVJNWvW1KlTp/Tdd9+pWrVqiY5OxMbGcsQCKer+wPr111+rc+fOevHFF1WjRg298MILatSokd566y298847+vjjjxOt86AvfMCTkrCPLV26VFevXtWlS5fUpUsXZcqUSWvXrtX48ePl6uqqIUOGWG/emBD7U6S0hPvG27dva/DgwZo0aZJq166tS5cuaeHChfr222+1aNEirVu3Tnny5LGW9fDwkMVi4SAiUg2f2s+Y+A/BPn36qH///oqIiFBMTIwCAgI0bNgwSfeOphUpUkQBAQFav359ounk+BBESov/ALtx44YkqWPHjurVq5cKFCig4sWLa8uWLWrYsKHy58+vDRs26NSpU4k+9AgVSGkJ96c9evTQypUrtXDhQr388stavny56tatqy5duigmJkbDhw9PdEMxif0pUl78vjE2Nlbp0qVTy5YtlTt3btWuXVuNGjVSvXr1lCVLFp09e1Yff/yxdb106dIRKpDq+OR+RiS8ZmL9+vX6/vvv9f333+ubb75R1apV5ezsrJw5c1rLbNy4URkzZtT06dP5ggaH+OKLL/TOO+9owYIFkqQ33nhD2bJlU8GCBbV06VLVrl1bBw8e1Pr1621u3Aikprlz52ru3Llas2aNVq1apfHjx+vcuXPWwNCkSRN17dpVFy5c0PLlyx3bWKRZ8+fP1zvvvKOIiAiVKVNGn376qcaOHavOnTtrzJgx+u2335QtWzYtXrw40T1UCBVITXzjfMqNHj1akmxuDHbu3DkVLVpUlSpV0tKlS9WuXTtNnjxZHTt2VEREhPVL2uHDh7V48WKHtR1pW9WqVeXk5KRJkybp3XffVdGiRWWxWPTdd9/JxcVFEydO1NSpUzVkyBC1adPG0c1FGvDTTz/p9u3bNsvOnz+vRo0aqUSJEpo/f77efPNNTZ48Wa+//roiIiIUGRmpRo0a6YsvvrDuj4HUFBsbq0uXLun8+fMqVKiQvv/+e1WqVElt2rTR+PHjVb9+ffXv318TJkxQgwYN1LBhQ0c3GWkY11g8xXbu3KmaNWuqbt26Wrp0qXX50qVLNX/+fDVu3FhdunTR559/rvfff1+StHr1aq1atUqffvqpnnvuOUmMAUbqSHi6PX7s+rVr17R9+3b169dPnp6eat68ufr3769x48ape/fuNuvHxMTIxcXFEU1HGvDNN9+oU6dOmj17tt566y15eHhIkgICAuTq6qoOHTrIz89Po0eP1gcffCBJGjdunKKiojRgwABrPVz7g5SWVB8zxig2Nla9evXSpk2bVLx4cbm6usrNzU0ff/yxihYtalOe/Skchb3jU6xUqVKaO3euDh06pDfeeMO6PEuWLDpw4IDat2+vYcOGWUPFrVu3NGXKFBljlDt3bmt5QgVSypAhQ6yn3ePH8kqyzjiWOXNmNWzYUEeOHFG5cuW0bds2pUuXThMmTNDx48dt6uJDECmpQ4cO6tatm95//319//33unXrliSpXbt22rBhgypWrKgJEyZYQ0VkZKQ2bdqkK1eu2NRDqEBKGTdunKT/7T8TslgscnFxUXBwsIYPH65s2bJp9erVmjFjhnr06JGoLvancBR63lMsXbp0ql+/viSpV69eatKkiZYvX67q1aurR48e6tmzp/755x/9+OOP8vT01IgRI3Tp0iWtXLmSC7aQ4o4ePaqNGzdq27Zt8vDwkL+/v02/u//sxZQpU7R582Zly5ZNx48fV5EiRRy8BUgr4s/afvnllzLGqHPnzpKkli1bqnjx4mrYsKE2bNigyMhI3bp1S7/99psGDBig0NBQa3Bmf4qU9Ouvv6p3797as2ePFi5cmORnePy+tHHjxqpevboaN26sVq1a6caNG5xJw1ODoVDPgDt37mjNmjXq1auXihcvrpUrV0qSRo4cqVWrVungwYMqU6aMMmXKpGXLlsnV1ZXhT0gVP/30k7744gvduHFDffr0kb+/v6TEX8IedO8VPgyRWhLuEz/88EN9/fXX+uqrr9S2bVudOnVKEydO1IIFCxQbG6vnnntOWbNm1bp169ifIlUYYxQSEqK3335br732mhYtWmRd/rBA+/fff8vX11dOTk7sT/FUIFg8hZLakSQMFy+99JJWrVolSbp48aJu3Lghb29v+fr6ymKxMLYSKS5hH/3pp580fvx43bx586Hh4mF1ACnh/i9a94eL6dOna/r06Wrbtq2ioqJ05coVHTx4UM8//7xeeuklOTk5sT9FqjHGaOPGjWrVqpVq1ar1r+Ei4XLCL54WBIunxJAhQ/Tyyy+rcePGkv49XJQoUSLRlHISFxYi9STsa5s3b1ZwcPBjhwsgJYwbN846n//9fTCpcPH111+rWbNmSp8+vU097E+R2uLi4hQSEvLI4QJ42rDHfArEj1WfOHGi1q1bJ8n2Qth4Hh4eql+/vsaOHatjx46pWrVqieriQxAp6f6bLcZ77bXX1L17d2XIkEFjxox5aD8GUlL8WPWWLVtKStwHnZ2dFRsbK0maOHGiOnfurC5dumju3LmKjo62qYv9KVJSUvtTJycn1ahRQwsWLNDGjRvVokULSexL8ezgjMVT4lHHqktSVFSUFi9erOXLl2vRokV8+CFVJDx6+80332jXrl1ydna2zqcuyRqQIyMj1adPH9WpU8eRTUYa9Khj1ROeuWjTpo3Onz+vzZs3O6TNSHsS7k8XLlyos2fP6saNG+revbuyZ89uHRbVsmVL1a5dWwsXLpTEmQs8/QgWDpbcserR0dFyc3OTxOl6pK6+ffvq22+/VatWrRQaGqqTJ0+qdu3aGjNmjCQpJCREkyZN0h9//KHp06erQoUKDm4x0ppHHaueMFzE70f54obU1K9fP82fP19FixZVVFSUTp48qaVLl6pSpUqSpA0bNuidd95RyZIltWHDBge3Fvh3fBt1sPiZcSSpevXq6tmz5yMNJ4kPFRKn65F6Zs2apaVLl2r16tUKDg7WG2+8oWPHjun7779Xly5dJEm1atVShw4dVK9ePb3yyisObjHSIovFolq1amnBggUKCQl54HASZ2dn6/43flYdQgVSy5QpUzRnzhwtX75c69evV2BgoC5duqRmzZpp06ZNkqTatWtrxowZcnV1feBQVOBpwhkLB0l4luH+Mw4hISH68ssvuRAWT51x48bp2rVrGjFihFasWKGAgAANGDBA4eHhmjRpkjp27Gg9cxGP2UqQ0h501vbu3bvasmWLWrZsKT8/Py6EhUMl3BfeunVLQ4cOVfHixfXuu+9q5cqVeueddzRq1Cht2rRJ27dv18KFCxNdS8kIBTztCBYOwFh1PAse9OXr7NmzcnNzk7+/v9q0aaNevXrp6NGjqlmzpiIjIzVw4ED179/fAS1GWsRYdTwLEvbT7du3q3z58tq7d69y586tmzdvqnHjxurevbu6deumVatWWWeI3LNnj8qWLevIpgOPhdjrAPE7l759+2rgwIFKnz69rl+/ri+++EJ9+vSRJPn5+al79+7KmDGjevfurV27djmyyUhjEg4JiYmJsZktJ2/evDpy5Ihu3bqlt956S9K9a36qV6+uGTNmqG/fvg5pM9Km+P1pv3791KdPH4WEhOjnn39WyZIltX37dlksFmug2Lx5s2rXri1JhAqkmh9//FE1a9aUJAUGBqpHjx66efOmKlasqDx58ujo0aPKli2bmjVrJkny9PRUjx499Nlnn6lUqVKObDrw2AgWDsJYdTytjDHWL2sjR45U06ZN9corr+jLL7/Uvn37JEmZMmXS3bt3NX/+fJ09e1YDBw6Up6enmjdvLicnJ+t0nkBqYKw6nlZxcXGKjY3VhQsXVLhwYc2aNUsLFy6Uj4+Ptczly5e1b98+RUZG6u+//9aECRMUFRWlAQMGyMXFRTExMY7bAOAxMRTKQRirjqdRwtP1I0aM0BdffKH3339fly9f1pYtW1SkSBF99NFHqlq1qvr162cdVpIzZ05t375drq6uDDFBimOsOp41rVq10qJFi1SxYkVt375d0r1rgFxdXRUdHS1/f39t3bpV+fLlU/r06bVv3z65uro6uNXA4yNYpALGquNZ8+eff2r8+PFq0KCBdfKAjRs3Kjg4WO7u7po5c6ZiY2MVFhamixcvqkaNGnJ2dlZMTIxcXFwc3Hr8lzFWHc+C+M/9+LNj8+fPV0REhCZNmqTcuXNbp46NioqSu7u7YmNjtWrVKsXExOiNN95gf4pnFj02hSX8EIyJiVFcXJx1qti8efNqw4YNSY5Vb9asmXUZkJpWr16tRo0aKXPmzKpfv751uZ+fn2JjY9WqVSvt3btXtWrVUubMmfXiiy9KuncUmQ9BpKQff/xRo0eP1pYtWxQYGKiff/5ZGzZsUMWKFSVJixcvTnKserZs2RirjlST8HP/7t27io6O1jvvvCNJyp8/v7p3767atWtrw4YNcnd3l3TvfhX169e3fj9gf4pnFeeBUxBj1fEsql+/vrp3765r167pxIkTiouLs8797+/vr+eee05bt25NtB7D9JCSGKuOZ0HCUDFy5Ei9+eabKliwoPr27at169apXr16mjBhgi5cuKBq1arp+PHjqlOnjoKDg22GPrE/xbOKoVAphLHqeBY8bJx5+/bttXDhQs2bN08NGjSQq6urrl+/rgoVKujDDz9Ut27dUrm1AGPV8Wz45JNPNH36dI0bN06enp4aNGiQMmbMqBUrVihTpkz6+eef1bNnT0VERChPnjzavHkzn/v4TyBYpDDGquNplTBUzJw5UwcOHFBMTIxKly6tzp07S5Lee+89zZ8/X2+//bYKFiyoHTt26OzZs3xZQ6phrDqeNcePH1fLli315Zdfqnr16vrll19Uq1YtTZs2Te3atbOWi4qK0uHDh1WmTBk5OTnRT/HfYJBiVq1aZSwWi8mSJYv58ccfbZ5bu3atyZQpk9m4cWOi9WJiYlKriYDp3bu38fX1Nb169TJdu3Y1WbJkMZ06dTLGGBMXF2e6detmLBaLadasmfnmm2/M3bt3jTHG+i+QUmJjY63/v3PnjomIiLD+vGbNGlOwYEHj5+dns86PP/5ooqKirD+zP0Vq++2330yJEiWMMcb88MMPJkOGDGbq1KnGGGMiIyPN4sWLzV9//WWzTsK+DjzLuMYiBTFWHU+7zZs3a8mSJVq+fLk+//xzVa9eXbdv37beN8VisWjixIl6//33tXHjRj333HNycXHhwkKkOMaq41kQ/5luEgz+uHPnjq5fv66xY8eqY8eOGjVqlN5//31J0sGDBzV37lyFhoba1MPUx/ivoCc/IUndcMnJyUnBwcEKCAjQwIEDtXLlSuvFg9evX1dUVJSyZcuW2k0FrP766y9lz55dFStW1NKlS9W+fXuNHz9eHTp00I0bN6zDTKZMmaJmzZqpVatWWrlyJV/WkOLiv2h98sknCg4OVvPmzTVlyhStXr1agwcPVlhYmPz8/DRp0iT9888/qlu3rm7duqVVq1bJYrHYfNEDUkJcXJz1eoioqCjr8hIlSqhhw4bq06ePunfvrq5du0qSbt++raCgIMXGxqp06dKOaDKQ4jjk+AT821j1GTNmyBijli1b2oxVd3d3t45lB1JaUhdqZ86cWXnz5tXChQvVsWNHjR071tont2/frlWrVunFF1/Uc889pxkzZujGjRvq1q2batWqpfTp0ztiM5CGHD9+XKtWrdIPP/xgHat++vRpTZs2Tb6+vpKkWrVqae/evYxVR6oyCWZ9HDdunLZs2SIPDw8VL15cgwYN0ogRI/TXX3/p888/l7u7uyIjI7V79279/fffOnDggJycnLhJI/6T6NFPQPyOoU+fPhowYIA8PDzk7OysgQMHWr+kzZgxQx07dtS3336r/fv3q0mTJtq/f79cXV2ZAhEpLuEH2LJly3Tu3DlJUr58+bR+/Xq9/fbbGjVqlLW/3r59W8HBwbp586Zy5cplref777/Xrl27CBVIFS4uLjLGqHr16lq8eLHq1q2r4OBgtWvXTrdu3dKSJUt08eJFubu7q1y5ctYva4QKpCSTYOam0aNHa8iQIXrppZckSQsXLlTFihWVMWNGLVq0SB999JFWrlypX3/9VcWLF9fBgwetn/uECvwnOe7yjv+WTZs2mQIFCpgdO3YYY4z5/vvvjaenp/n6669tyn3wwQfG29vbrF271hjDhYVIeXFxcdb/9+/f3+TOndsEBwebyMhIY8y9i2CdnJzMhx9+aJYuXWrWrVtn/Pz8TIkSJawXaHNhIVJafD9N2F8PHTpk8uTJYz7//HPj4+NjJk2aZH3ul19+MU2aNDH79u1L9bYCxhizZ88e8/bbb5s1a9ZYl+3cudO89NJLpnr16tZlN27csFmPz338lxEsnpA5c+aYihUrGmOMWbJkicmYMaOZNm2aMcaYiIgIs379emvZ9957z2TKlMmsWLHCIW1F2jRs2DCTNWtWs3v3busHXfyXuGXLlplixYoZX19fU7FiRdOkSRMTHR1tjOFDECkvYXC9ffu2zXMffPCBsVgsZtCgQdZlt27dMg0bNjSvv/46oRcOsXDhQlOmTBnzwgsvmEOHDlmXx8TEmA0bNpiiRYualStXGmNsZ9BLGJyB/yLOFycDY9XxrLl27Zq2bt2q4OBgvfLKK/rrr7+0f/9+zZgxQ9WqVdM777yjmjVrKjw8XG5ubsqePbssFgtj1ZHiDGPV8QwqW7ascubMqUOHDmnFihUqUaKEpHuzkL388su6efOmdchpwn0oN7/Dfx174sfEWHU8iywWi44dO/b/2ruzkKj+Po7jnzNZTY6pSKJGoylGRYsoSTvRbmE3EQltVmaY7YsWBZZkhMZYWUxFZVZ0kQVtQ0EURctFYBu0SdtkF1FQUlhk4+RzEQ3Nv56e9PR/JvP9ggHPOXOOXw7izOd3vud3dP/+fV26dEnLly9XXl6eqqurlZ+fL6fTqdDQUNntdkVFRflm1SFU4N/USK86WqjExETt3LlT48ePl8vlUkVFhW9bhw4dFB4ezt8lWiWevN0E334Irl69WgcOHFBeXp6ys7MVHBysM2fOKD09XfPnz9fw4cNls9m0adMmvXz5Ujdu3FBQUBAjawiYvXv3Ki8vT16vVzk5ORo9erRGjRqlGTNmyDAM7d+/P9AlopWqqqrS5s2bNW3aNI0bN06SdO3aNWVlZalTp066ePGiJKmurk4hISG+/bxeL1MfI6DcbrcWLFighw8favDgwerVq5cuX76s+/fv6+7duwzOoNUhWDTD+vXrVVZWptOnT6tnz54KCQnxhY7jx49rzZo1ev36teLj4xUdHa3Kykq1bduWD0EEXE1Njerr69WtWzdJX67AjRkzRgMGDFBRUVGAq0NrdPjwYZWUlOjt27c6duyYr6XE6/XqwoULWrhwoUpKSjRhwgS/1rxvB3qAQHr27JkWL16sU6dOaezYsRo5cqSWL18uifCL1oco3UT0qqMli42NlfRl5PfWrVsqLi7Wq1evtG7dusAWhlaLXnW0dHFxcdq2bZu8Xq+CgoIUExPj20aHAlobvuk20T971Z1Op54+fSrDMORyufTu3TstXbpUoaGhvn3oVcefpLGxUVVVVXI4HPJ4PLp+/bqCgoIYWUNAfO1Vnz9/vlwul7p06aKZM2dKolcdLYfdbtfWrVu1aNEilZeX6+PHj5o9ezYBGK0OrVDNQK86Wrr6+nrdu3dPSUlJPKkYfwR61fE3cLvdmj59uiIiInTw4EG/QUagNSBYNBO96vhbMKEA/hT0quNv8OzZM1ksFtnt9kCXAvzfMQTUTPSq429BqMCfgl51/A3i4uICXQIQMPynNuFrr3pxcfF3veoAgKb72qvu8XhUXl6u8vJySdysDQAtAa1QJtGrDgC/H73qANDyECx+I3rVAeD3oVcdAFoWggUAAAAA0xheBwAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAC/bObMmTIM47vXo0ePTB+7oqJC4eHh5osEAAREUKALAAC0LGlpadq3b5/fusjIyABV82Mej0dt27YNdBkA0KpwxQIA0CTt27dXdHS036tNmzY6ceKEUlJSZLValZCQoMLCQjU0NPj2Ky0tVZ8+fWSz2WS325Wbm6u6ujpJ0sWLFzVr1iy9ffvWdxVk3bp1kiTDMHT8+HG/GsLDw1VRUSFJcrvdMgxDhw8f1rBhw2S1WnXo0CFJ0p49e9SzZ09ZrVb16NFDTqfTd4xPnz5pwYIFiomJkdVqVVxcnDZu3PjvnTgA+MtxxQIAYNrly5c1Y8YMlZWVaejQoXr8+LHmzp0rSVq7dq0kyWKxqKysTPHx8Xry5Ilyc3OVn58vp9OpQYMGacuWLSooKFB1dbUkKSQkpEk1rFq1Sg6HQ8nJyb5wUVBQoO3btys5OVk3b95Udna2bDabMjMzVVZWppMnT6qyslKxsbF6/vy5nj9//ntPDAC0IgQLAECTuFwuvy/948aNU21trVatWqXMzExJUkJCgtavX6/8/HxfsFiyZIlvn65du6qoqEg5OTlyOp1q166dwsLCZBiGoqOjm1XXkiVLNHHiRN/y2rVr5XA4fOvi4+N179497dq1S5mZmaqpqVG3bt00ZMgQGYahuLi4Zv1eAMAXBAsAQJMMHz5cO3bs8C3bbDb17dtXV69e1YYNG3zrvV6vPn78qA8fPig4OFjnzp3Txo0b9eDBA717904NDQ1+283q16+f7+f379/r8ePHysrKUnZ2tm99Q0ODwsLCJH25EX306NHq3r270tLSlJ6erjFjxpiuAwBaK4IFAKBJbDabEhMT/dbV1dWpsLDQ74rBV1arVW63W+np6Zo3b542bNigiIgIXblyRVlZWfr06dNPg4VhGGpsbPRb5/F4fljXt/VI0u7du9W/f3+/97Vp00aSlJKSoqdPn+rMmTM6d+6cJk+erFGjRuno0aP/4wwAAH6EYAEAMC0lJUXV1dXfBY6vrl+/rs+fP8vhcMhi+TJvSGVlpd972rVrJ6/X+92+kZGRevHihW/54cOH+vDhw0/riYqKUufOnfXkyRNNnTr1v74vNDRUGRkZysjI0KRJk5SWlqY3b94oIiLip8cHAHyPYAEAMK2goEDp6emKjY3VpEmTZLFYdPv2bd25c0dFRUVKTEyUx+PRtm3bNGHCBF29elU7d+70O0bXrl1VV1en8+fPKykpScHBwQoODtaIESO0fft2DRw4UF6vVytXrvylqWQLCwu1aNEihYWFKS0tTfX19aqqqlJtba2WLVum0tJSxcTEKDk5WRaLRUeOHFF0dDTP0gCAZmK6WQCAaWPHjpXL5dLZs2eVmpqqAQMGaPPmzb4bopOSklRaWqri4mL17t1bhw4d+m5q10GDBiknJ0cZGRmKjIxUSUmJJMnhcMhut2vo0KGaMmWKVqxY8Uv3ZMyZM0d79uzRvn371KdPHw0bNkwVFRWKj4+XJHXs2FElJSXq16+fUlNT5Xa7dfr0ad8VFQBA0xiN/2xcBQAAAIAmYlgGAAAAgGkECwAAAACmESwAAAAAmEawAAAAAGAawQIAAACAaQQLAAAAAKYRLAAAAACYRrAAAAAAYBrBAgAAAIBpBAsAAAAAphEsAAAAAJhGsAAAAABg2n8ApZnOGou9KNoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot feature importances\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.bar(feature_names, importances, color='green')\n",
+    "plt.xlabel('Features')\n",
+    "plt.ylabel('Importance')\n",
+    "plt.title('Feature Importances for Iris Dataset (OIKANClassifier)')\n",
+    "plt.xticks(rotation=45, ha='right')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "d48506eb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:19.387688Z",
+     "iopub.status.busy": "2025-05-11T18:50:19.387358Z",
+     "iopub.status.idle": "2025-05-11T18:50:19.393063Z",
+     "shell.execute_reply": "2025-05-11T18:50:19.392113Z"
+    },
+    "papermill": {
+     "duration": 0.046972,
+     "end_time": "2025-05-11T18:50:19.394517",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:19.347545",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model saved to outputs/iris_model.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save the model\n",
+    "model.save(\"outputs/iris_model.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "8e533860",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:19.475788Z",
+     "iopub.status.busy": "2025-05-11T18:50:19.474916Z",
+     "iopub.status.idle": "2025-05-11T18:50:19.479763Z",
+     "shell.execute_reply": "2025-05-11T18:50:19.478992Z"
+    },
+    "papermill": {
+     "duration": 0.046966,
+     "end_time": "2025-05-11T18:50:19.481626",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:19.434660",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load the model\n",
+    "loaded_model = OIKANClassifier()\n",
+    "loaded_model.load(\"outputs/iris_model.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "6b3a35fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:19.564518Z",
+     "iopub.status.busy": "2025-05-11T18:50:19.564152Z",
+     "iopub.status.idle": "2025-05-11T18:50:19.570369Z",
+     "shell.execute_reply": "2025-05-11T18:50:19.569186Z"
+    },
+    "papermill": {
+     "duration": 0.050578,
+     "end_time": "2025-05-11T18:50:19.571930",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:19.521352",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original Formulas:\n",
+      "Class 0: Class 0: 0.502330*x0 + 0.047963*x1 + 0.068156*x0^2 + 0.060449*x0 x1 + -0.348062*x0 x2 + -0.302223*x0 x3 + 0.788278*x1^2 + -0.205325*x1 x2 + -0.123608*x1 x3 + -0.158860*x2^2 + 0.020679*x0^3 + -0.001237*exp_x0 + -0.104283*exp_x1 + 0.000461*x2^3 + 0.006598*exp_x2 + 0.370910*sin_x2 + 0.007158*x3^3\n",
+      "Class 1: Class 1: 0.095236*x0 + 0.164205*x0^2 + 0.029835*x0 x1 + 0.002185*x0 x2 + 0.101242*x1 x2 + -0.016630*x2^2 + -0.123284*x2 x3 + -0.007198*x0^3 + -0.000386*exp_x0 + -0.003938*exp_x1 + -0.026264*x2^3 + 0.004455*exp_x2 + -0.037553*x3^3\n",
+      "Class 2: Class 2: -0.713402*x0 + -0.156225*x1 + -0.109722*x0^2 + -0.039182*x0 x1 + 0.293238*x0 x2 + 0.401316*x0 x3 + -0.732060*x1^2 + 0.093550*x1 x2 + 0.104036*x1 x3 + 0.216042*x2^2 + -0.020035*x0^3 + 0.001268*exp_x0 + 0.100670*exp_x1 + 0.014878*x2^3 + -0.008931*exp_x2 + -0.299646*sin_x2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Original formulas\n",
+    "print(\"Original Formulas:\")\n",
+    "formulas_loaded = loaded_model.get_formula(type='original')\n",
+    "for i, formula in enumerate(formulas_loaded):\n",
+    "    print(f\"Class {i}: {formula}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e0021c5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:19.651564Z",
+     "iopub.status.busy": "2025-05-11T18:50:19.651190Z",
+     "iopub.status.idle": "2025-05-11T18:50:27.484441Z",
+     "shell.execute_reply": "2025-05-11T18:50:27.483348Z"
+    },
+    "papermill": {
+     "duration": 7.874978,
+     "end_time": "2025-05-11T18:50:27.486170",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:19.611192",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Simplified Formulas:\n",
+      "Class 0: Class 0: 0.04796*x1 + 0.00046*x2**3 + 0.00660*exp(x2) + 0.00716*x3**3 + 0.06816*x0**2 + 0.02068*x0**3 + 0.50233*x0 + 0.37091*sin(x2) + 0.78828*x1**2 - 0.00124*exp(x0) - 0.10428*exp(x1) - 0.15886*x2**2 + 0.06045*x0*x1 - 0.30222*x0*x3 - 0.20533*x1*x2 - 0.34806*x0*x2 - 0.12361*x1*x3\n",
+      "Class 1: Class 1: 0.00445*exp(x2) + 0.16421*x0**2 + 0.09524*x0 - 0.00394*exp(x1) - 0.02626*x2**3 - 0.00720*x0**3 - 0.01663*x2**2 - 0.03755*x3**3 - 0.00039*exp(x0) + 0.00218*x0*x2 + 0.10124*x1*x2 + 0.02983*x0*x1 - 0.12328*x2*x3\n",
+      "Class 2: Class 2: 0.21604*x2**2 + 0.01488*x2**3 + 0.00127*exp(x0) + 0.10067*exp(x1) - 0.29965*sin(x2) - 0.00893*exp(x2) - 0.15623*x1 - 0.02004*x0**3 - 0.71340*x0 - 0.73206*x1**2 - 0.10972*x0**2 + 0.09355*x1*x2 + 0.10404*x1*x3 + 0.29324*x0*x2 + 0.40132*x0*x3 - 0.03918*x0*x1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Simplified formulas\n",
+    "print(\"\\nSimplified Formulas:\")\n",
+    "simplified_formulas = loaded_model.get_formula(type='sympy')\n",
+    "for i, formula in enumerate(simplified_formulas):\n",
+    "    print(f\"Class {i}: {formula}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ad228ce1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:27.567295Z",
+     "iopub.status.busy": "2025-05-11T18:50:27.566844Z",
+     "iopub.status.idle": "2025-05-11T18:50:27.627224Z",
+     "shell.execute_reply": "2025-05-11T18:50:27.625751Z"
+    },
+    "papermill": {
+     "duration": 0.102968,
+     "end_time": "2025-05-11T18:50:27.628905",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:27.525937",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "LaTeX Formulas:\n",
+      "Class 0: Class 0: 0.02068 x_{0}^{3} + 0.06816 x_{0}^{2} + 0.06045 x_{0} x_{1} - 0.34806 x_{0} x_{2} - 0.30222 x_{0} x_{3} + 0.50233 x_{0} + 0.78828 x_{1}^{2} - 0.20533 x_{1} x_{2} - 0.12361 x_{1} x_{3} + 0.04796 x_{1} + 0.00046 x_{2}^{3} - 0.15886 x_{2}^{2} + 0.00716 x_{3}^{3} - 0.00124 e^{x_{0}} - 0.10428 e^{x_{1}} + 0.0066 e^{x_{2}} + 0.37091 \\sin{\\left(x_{2} \\right)}\n",
+      "Class 1: Class 1: - 0.0072 x_{0}^{3} + 0.16421 x_{0}^{2} + 0.02983 x_{0} x_{1} + 0.00218 x_{0} x_{2} + 0.09524 x_{0} + 0.10124 x_{1} x_{2} - 0.02626 x_{2}^{3} - 0.01663 x_{2}^{2} - 0.12328 x_{2} x_{3} - 0.03755 x_{3}^{3} - 0.00039 e^{x_{0}} - 0.00394 e^{x_{1}} + 0.00445 e^{x_{2}}\n",
+      "Class 2: Class 2: - 0.02004 x_{0}^{3} - 0.10972 x_{0}^{2} - 0.03918 x_{0} x_{1} + 0.29324 x_{0} x_{2} + 0.40132 x_{0} x_{3} - 0.7134 x_{0} - 0.73206 x_{1}^{2} + 0.09355 x_{1} x_{2} + 0.10404 x_{1} x_{3} - 0.15623 x_{1} + 0.01488 x_{2}^{3} + 0.21604 x_{2}^{2} + 0.00127 e^{x_{0}} + 0.10067 e^{x_{1}} - 0.00893 e^{x_{2}} - 0.29965 \\sin{\\left(x_{2} \\right)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# LaTeX formulas\n",
+    "print(\"\\nLaTeX Formulas:\")\n",
+    "latex_formulas = loaded_model.get_formula(type='latex')\n",
+    "for i, formula in enumerate(latex_formulas):\n",
+    "    print(f\"Class {i}: {formula}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ce1885b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.039064,
+     "end_time": "2025-05-11T18:50:27.707780",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:27.668716",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# 3. Regression: California Housing Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "22ae1d2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:27.787270Z",
+     "iopub.status.busy": "2025-05-11T18:50:27.786868Z",
+     "iopub.status.idle": "2025-05-11T18:50:27.792792Z",
+     "shell.execute_reply": "2025-05-11T18:50:27.791965Z"
+    },
+    "papermill": {
+     "duration": 0.047618,
+     "end_time": "2025-05-11T18:50:27.794222",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:27.746604",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "from sklearn.datasets import fetch_california_housing\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import mean_squared_error, r2_score\n",
+    "from oikan import OIKANRegressor\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "24088888",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:27.875028Z",
+     "iopub.status.busy": "2025-05-11T18:50:27.874662Z",
+     "iopub.status.idle": "2025-05-11T18:50:29.645499Z",
+     "shell.execute_reply": "2025-05-11T18:50:29.643801Z"
+    },
+    "papermill": {
+     "duration": 1.813817,
+     "end_time": "2025-05-11T18:50:29.648255",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:27.834438",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load California Housing dataset\n",
+    "data = fetch_california_housing()\n",
+    "X, y = data.data, data.target\n",
+    "feature_names = data.feature_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "92519e68",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:29.743070Z",
+     "iopub.status.busy": "2025-05-11T18:50:29.742712Z",
+     "iopub.status.idle": "2025-05-11T18:50:29.750406Z",
+     "shell.execute_reply": "2025-05-11T18:50:29.749543Z"
+    },
+    "papermill": {
+     "duration": 0.049578,
+     "end_time": "2025-05-11T18:50:29.751888",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:29.702310",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Split into training and testing sets\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "75c51b6c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:29.832651Z",
+     "iopub.status.busy": "2025-05-11T18:50:29.832252Z",
+     "iopub.status.idle": "2025-05-11T18:50:29.838088Z",
+     "shell.execute_reply": "2025-05-11T18:50:29.837293Z"
+    },
+    "papermill": {
+     "duration": 0.048594,
+     "end_time": "2025-05-11T18:50:29.839859",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:29.791265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Initialize OIKANRegressor\n",
+    "model = OIKANRegressor(\n",
+    "    hidden_sizes=[32, 32],\n",
+    "    activation='relu',\n",
+    "    augmentation_factor=1,\n",
+    "    alpha=0.1,\n",
+    "    sigma=0.1,\n",
+    "    epochs=100,\n",
+    "    lr=0.001,\n",
+    "    batch_size=32,\n",
+    "    top_k=10,\n",
+    "    evaluate_nn=False,\n",
+    "    verbose=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "6d398539",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:50:29.919605Z",
+     "iopub.status.busy": "2025-05-11T18:50:29.919244Z",
+     "iopub.status.idle": "2025-05-11T18:51:55.191017Z",
+     "shell.execute_reply": "2025-05-11T18:51:55.188917Z"
+    },
+    "papermill": {
+     "duration": 85.314024,
+     "end_time": "2025-05-11T18:51:55.192875",
+     "exception": false,
+     "start_time": "2025-05-11T18:50:29.878851",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Training: 100%|██████████| 100/100 [01:24<00:00,  1.19it/s, loss=0.4432]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data: features shape: (16512, 8) | target shape: (16512, 1)\n",
+      "Augmented data: features shape: (16512, 8) | target shape: (16512, 1)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 8.667e+02, tolerance: 6.691e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n",
+      "/usr/local/lib/python3.11/dist-packages/sklearn/linear_model/_coordinate_descent.py:631: ConvergenceWarning: Objective did not converge. You might want to increase the number of iterations, check the scale of the features or consider increasing regularisation. Duality gap: 6.657e+02, tolerance: 6.691e+00\n",
+      "  model = cd_fast.enet_coordinate_descent(\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Fit the model\n",
+    "model.fit(X_train, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "d60d4546",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:55.341281Z",
+     "iopub.status.busy": "2025-05-11T18:51:55.340909Z",
+     "iopub.status.idle": "2025-05-11T18:51:55.347806Z",
+     "shell.execute_reply": "2025-05-11T18:51:55.347028Z"
+    },
+    "papermill": {
+     "duration": 0.069458,
+     "end_time": "2025-05-11T18:51:55.349422",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:55.279964",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Make predictions\n",
+    "y_pred = model.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "243616bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:55.450296Z",
+     "iopub.status.busy": "2025-05-11T18:51:55.449902Z",
+     "iopub.status.idle": "2025-05-11T18:51:55.457894Z",
+     "shell.execute_reply": "2025-05-11T18:51:55.456956Z"
+    },
+    "papermill": {
+     "duration": 0.059674,
+     "end_time": "2025-05-11T18:51:55.459420",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:55.399746",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mean Squared Error: 0.8417\n",
+      "R^2 Score: 0.3577\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Evaluate performance\n",
+    "mse = mean_squared_error(y_test, y_pred)\n",
+    "r2 = r2_score(y_test, y_pred)\n",
+    "print(f\"Mean Squared Error: {mse:.4f}\")\n",
+    "print(f\"R^2 Score: {r2:.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "523425d8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:55.559832Z",
+     "iopub.status.busy": "2025-05-11T18:51:55.559486Z",
+     "iopub.status.idle": "2025-05-11T18:51:55.564557Z",
+     "shell.execute_reply": "2025-05-11T18:51:55.563619Z"
+    },
+    "papermill": {
+     "duration": 0.056951,
+     "end_time": "2025-05-11T18:51:55.566010",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:55.509059",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Symbolic Formula:\n",
+      "0.016541*x1 + 0.000361*x4 + -0.005436*x7 + 0.054910*x0^2 + 0.003279*x0 x1 + 0.000008*x0 x4 + 0.004007*x0 x5 + 0.000944*x0 x6 + -0.000631*x0 x7 + -0.000697*x1^2 + -0.001050*x1 x2 + 0.000003*x1 x4 + -0.000379*x1 x5 + -0.000428*x1 x6 + -0.000074*x1 x7 + 0.002858*x2^2 + -0.000023*x2 x4 + -0.003552*x2 x6 + 0.000169*x2 x7 + -0.000010*x3 x4 + 0.009420*x3 x5 + -0.003057*x3 x7 + 0.000011*x4 x5 + -0.000001*x4 x6 + 0.000003*x4 x7 + 0.000157*x5^2 + -0.000159*x5 x6 + 0.001021*x5 x7 + 0.000293*x6^2 + -0.000057*x6 x7 + 0.000018*x7^2 + 0.000030*exp_x5 + 0.049820*sin_x5 + -0.001212*x3^3 + -0.000013*exp_x3 + 0.000011*x1^3 + -0.003295*x0^3 + -0.000007*exp_x0 + -0.000005*x2^3 + 0.000014*exp_x2 + -0.000014*x6^3 + 0.000022*exp_x6 + -0.000017*exp_x4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get symbolic formula\n",
+    "print(\"\\nSymbolic Formula:\")\n",
+    "formula = model.get_formula()\n",
+    "print(formula)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "b44df04a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:55.666905Z",
+     "iopub.status.busy": "2025-05-11T18:51:55.666560Z",
+     "iopub.status.idle": "2025-05-11T18:51:55.672348Z",
+     "shell.execute_reply": "2025-05-11T18:51:55.671282Z"
+    },
+    "papermill": {
+     "duration": 0.057876,
+     "end_time": "2025-05-11T18:51:55.673815",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:55.615939",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Feature Importances:\n",
+      "[0.34882481 0.11680076 0.03988492 0.07131129 0.00227446 0.33802762\n",
+      " 0.0284463  0.05442985]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get feature importances\n",
+    "print(\"\\nFeature Importances:\")\n",
+    "importances = model.feature_importances()\n",
+    "print(importances)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "66129578",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:55.776716Z",
+     "iopub.status.busy": "2025-05-11T18:51:55.776391Z",
+     "iopub.status.idle": "2025-05-11T18:51:56.002214Z",
+     "shell.execute_reply": "2025-05-11T18:51:56.001078Z"
+    },
+    "papermill": {
+     "duration": 0.278303,
+     "end_time": "2025-05-11T18:51:56.003920",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:55.725617",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAJOCAYAAAAqFJGJAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuNSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/xnp5ZAAAACXBIWXMAAA9hAAAPYQGoP6dpAACTM0lEQVR4nOzdeVxN+f8H8NctWrSTSkRRZA+RfY3sjH35ys4YY9DYYkRImGHswjB2Y+zbYIgwGEvMMHbGFiprEYp6//7od890VaTTuDVez8fjPrjnnnvu55zO9jrn8/kcjYgIiIiIiIiIVDDQdwGIiIiIiCjnY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwIKL/vKtXr6JRo0awsrKCRqPBli1b9F2kDzZ+/HhoNBqdYc7OzujRo4fOMH3P682bN6HRaLBs2bKP+rv6FhYWBo1Gg7CwMH0Xhd5y584dmJiY4MiRI/ouCuUAISEhKFy4MOLj4/VdlByJwYLeadmyZdBoNGm+Ro0a9a/85tGjRzF+/Hg8ffr0X5m+GtrlcerUKX0XJdPmz5//yZ30de/eHefOnUNQUBBWrlwJT0/Pf/03Y2NjERgYiPLly8Pc3BympqYoU6YMRo4ciXv37v1rv6uPef03aYPKd999l+bn2sD18OHDj1yy7OPt/bSJiQkcHR3h4+OD2bNn49mzZ5mednbbH2dm/zVhwgR4eXmhRo0aqT7bsWMHGjdujHz58sHExATFixfHsGHD8OjRo1Tj9ujRA+bm5jrD6tatizJlyqQaNzQ0FHny5EHFihXx+PFjnc8uXryo/J3SW65169aFRqNBixYtUn2W1jahDbbal6GhIezs7NCuXTtcvHgxzd+gtPXo0QMJCQlYuHChvouSI+XSdwEoZ5gwYQJcXFx0hqW1M80KR48eRWBgIHr06AFra+t/5Tc+ZfPnz4etrW2qK93/VS9fvsSxY8cwZswYfPnllx/lN//++294e3vj9u3baN++Pfr16wcjIyOcPXsWS5YswebNm3HlyhXVv3P58mUYGPxzfUgf8/q2IkWK4OXLl8idO7defl9fateujZcvX8LIyEhvZdDup1+/fo3IyEiEhYVhyJAhmDFjBrZt24Zy5cp98DSz2/74Q/dfDx48wPLly7F8+fJUnw0bNgzTp09H+fLlMXLkSOTNmxenT5/G3Llz8dNPPyE0NBQlSpT44DLu378fLVq0QIkSJbBv3z7kzZtX5/NVq1bBwcEBT548wYYNG9CnT590p7Vjxw6Eh4ejUqVKGfrtr776CpUrV8br169x9uxZhISEICwsDH/99RccHBw+eF4+RSYmJujevTtmzJiBQYMGpbpTTO/GYEEZ0qRJkxx/5TMuLg5mZmb6LobevHjxAnny5NF3MT66Bw8eAECWnhS9a1168+YN2rRpg6ioKISFhaFmzZo6nwcFBWHq1KlZUg5jY2Od9x97XtOivRL7qTEwMND7fL+9n/b398f+/fvRvHlztGzZEhcvXoSpqakeS/jxrVq1Crly5Up15X/t2rWYPn06OnbsiNWrV8PQ0FD5rEePHqhXrx7at2+P06dPI1eujJ8qHTx4EC1atEDx4sXTDBUigjVr1qBLly64ceMGVq9enW6wKFy4MJ49e4bAwEBs27YtQ79fq1YttGvXTnlfokQJDBgwACtWrMCIESMyPB9ZIacdc1Lu6zp06IBp06bhwIEDqF+/vp5LlrOwKhRliV27dqFWrVowMzODhYUFmjVrhvPnz+uMc/bsWfTo0QNFixaFiYkJHBwc0KtXL51bzuPHj8fw4cMBAC4uLspt3Zs3b76z7rZGo8H48eN1pqPRaHDhwgV06dIFNjY2Oid4q1atQqVKlWBqaoq8efOiU6dOuHPnTqbmXXt7/Pbt22jevDnMzc1RsGBBzJs3DwBw7tw51K9fH2ZmZihSpAjWrFmj831tNYZDhw6hf//+yJcvHywtLeHr64snT56k+r358+ejdOnSMDY2hqOjIwYOHJjqdrr29nx4eDhq166NPHnyYPTo0XB2dsb58+dx8OBBZdnWrVsXAPD48WMMGzYMZcuWhbm5OSwtLdGkSRP8+eefOtPW3nL/+eefERQUhEKFCsHExAQNGjTAtWvXUpX3+PHjaNq0KWxsbGBmZoZy5cph1qxZOuNcunQJ7dq1Q968eWFiYgJPT89UB9LXr18jMDAQbm5uMDExQb58+VCzZk3s3bs33b/N+PHjUaRIEQDA8OHDodFo4OzsrHx+5swZNGnSBJaWljA3N0eDBg3w+++/p/n3OXjwIL744gvY2dmhUKFC6f7mxo0b8eeff2LMmDGpQgUAWFpaIigoSHl/+PBhtG/fHoULF4axsTGcnJwwdOhQvHz5Mt3f0ErZxuLfnlftOnXhwgXUq1cPefLkQcGCBTFt2jSdaaS1nWZk289q69evV7ZxW1tb/O9//8Pdu3d1xqlbt66y/qfUo0cPnWUHAD/99BMqVaoECwsLWFpaomzZsjrrcVptLDK6zADg1q1baNmyJczMzGBnZ4ehQ4diz549qttt1K9fH2PHjsWtW7ewatUqZbja/TEA/Pjjj6hfvz7s7OxgbGyMUqVKYcGCBanKcOrUKfj4+MDW1hampqZwcXFBr169dMZJSkrCzJkzUbp0aZiYmMDe3h79+/fX2Qe+a/+Vni1btsDLyytVFabAwEDY2Nhg0aJFOqECAKpUqYKRI0fi3Llz2LBhwzunn9Lhw4fRrFkzuLq6Yt++fciXL1+qcY4cOYKbN2+iU6dO6NSpEw4dOoSIiIg0p2dhYYGhQ4di+/btOH36dIbLkVKtWrUAANevX9cZfvfuXfTq1Qv29vYwNjZG6dKlsXTp0lTfz+h6md4xBwDi4+Mxbtw4uLq6Kvu4ESNGpGrDsHfvXtSsWRPW1tYwNzdHiRIllGlozZkzB6VLl0aePHlgY2MDT0/PVMfUrNivV6pUCXnz5sXWrVszuKRJi3csKENiYmJS1WG2tbUFAKxcuRLdu3eHj48Ppk6dihcvXmDBggWoWbMmzpw5oxyg9+7di7///hs9e/aEg4MDzp8/j0WLFuH8+fP4/fffodFo0KZNG1y5cgVr167F999/r/xG/vz5lauxH6J9+/Zwc3PD5MmTISIAkq8Yjx07Fh06dECfPn3w4MEDzJkzB7Vr18aZM2cydbU3MTERTZo0Qe3atTFt2jSsXr0aX375JczMzDBmzBh07doVbdq0QUhICHx9fVGtWrVUVcu+/PJLWFtbY/z48bh8+TIWLFiAW7duKScsQPKBPjAwEN7e3hgwYIAy3smTJ3HkyBGd6iePHj1CkyZN0KlTJ/zvf/+Dvb096tati0GDBsHc3BxjxowBANjb2wNIrr6zZcsWtG/fHi4uLoiKisLChQtRp04dXLhwAY6OjjrlnTJlCgwMDDBs2DDExMRg2rRp6Nq1K44fP66Ms3fvXjRv3hwFChTA4MGD4eDggIsXL2LHjh0YPHgwAOD8+fOoUaMGChYsiFGjRsHMzAw///wzWrdujY0bN+Kzzz5T5j04OBh9+vRBlSpVEBsbi1OnTuH06dNo2LBhmn+XNm3awNraGkOHDkXnzp3RtGlT5QTj/PnzqFWrFiwtLTFixAjkzp0bCxcuRN26dXHw4EF4eXnpTOuLL75A/vz5ERAQgLi4uHTXBW0g6tatW7rjpLR+/Xq8ePECAwYMQL58+XDixAnMmTMHERERWL9+fYam8bHm9cmTJ2jcuDHatGmDDh06YMOGDRg5ciTKli2LJk2apFu2jGz77/PixYs021G8ePEi1bBly5ahZ8+eqFy5MoKDgxEVFYVZs2bhyJEjmdrG9+7di86dO6NBgwbK3aaLFy/iyJEjynqcnowss7i4ONSvXx/3799XtpM1a9bgwIEDH1TO9HTr1g2jR4/Gr7/+ir59+yrzpGZ/DAALFixA6dKl0bJlS+TKlQvbt2/HF198gaSkJAwcOBAAEB0djUaNGiF//vwYNWoUrK2tcfPmTWzatEmnjP3791f+bl999RVu3LiBuXPn4syZM8q+bebMmenuv9Ly+vVrnDx5EgMGDNAZfvXqVVy+fBk9evSApaVlmt/19fXFuHHjsGPHDnTq1Om9y/jIkSNo2rQpXFxcEBoaqiyrt61evRrFihVD5cqVUaZMGeTJkwdr165VAtzbBg8ejO+//x7jx4/P8F2LlLQh0MbGRhkWFRWFqlWrQqPR4Msvv0T+/Pmxa9cu9O7dG7GxsRgyZAiAD18v0zrmJCUloWXLlvjtt9/Qr18/lCxZEufOncP333+PK1euKJ1LnD9/Hs2bN0e5cuUwYcIEGBsb49q1azoN7hcvXoyvvvoK7dq1w+DBg/Hq1SucPXsWx48fR5cuXZTpZNV+vWLFimzwnxlC9A4//vijAEjzJSLy7Nkzsba2lr59++p8LzIyUqysrHSGv3jxItX0165dKwDk0KFDyrBvv/1WAMiNGzd0xr1x44YAkB9//DHVdADIuHHjlPfjxo0TANK5c2ed8W7evCmGhoYSFBSkM/zcuXOSK1euVMPTWx4nT55UhnXv3l0AyOTJk5VhT548EVNTU9FoNPLTTz8pwy9dupSqrNppVqpUSRISEpTh06ZNEwCydetWERGJjo4WIyMjadSokSQmJirjzZ07VwDI0qVLlWF16tQRABISEpJqHkqXLi116tRJNfzVq1c60xVJXubGxsYyYcIEZdiBAwcEgJQsWVLi4+OV4bNmzRIAcu7cORERefPmjbi4uEiRIkXkyZMnOtNNSkpS/t+gQQMpW7asvHr1Sufz6tWri5ubmzKsfPny0qxZs1Tlfh/tevPtt9/qDG/durUYGRnJ9evXlWH37t0TCwsLqV27tjJM+/epWbOmvHnz5r2/V6FCBbGysspw+dLaLoKDg0Wj0citW7eUYdp1OqUiRYpI9+7dlff/5rxq16kVK1Yow+Lj48XBwUHatm2bqgwpt9OMbvtp0U7vfa8HDx6IiEhCQoLY2dlJmTJl5OXLl8p0duzYIQAkICBAZ57S2ha6d+8uRYoUUd4PHjxYLC0t3/n3124XBw4c0Jl+RpbZ9OnTBYBs2bJFGfby5Utxd3dPNc20pLVfepuVlZVUqFBBea92f5zeNHx8fKRo0aLK+82bN7+3bIcPHxYAsnr1ap3hu3fvTjU8vf1XWq5duyYAZM6cOTrDt2zZIgDk+++/f+f3LS0tpWLFisr77t27i5mZmc44derUkbx584qFhYWULl1aoqOj051eQkKC5MuXT8aMGaMM69Kli5QvXz7VuHXq1JHSpUuLiEhgYKAAkPDwcBFJezvXrn9Lly6VBw8eyL1792T37t3i6uoqGo1GTpw4oYzbu3dvKVCggDx8+FDnNzt16iRWVlbK3/VD1sv0jjkrV64UAwMDOXz4sM7wkJAQASBHjhwREZHvv/9eZztOS6tWrZRlkp6s3K/369dPTE1N3/l7lBqrQlGGzJs3D3v37tV5AclXvZ4+fYrOnTvj4cOHysvQ0BBeXl46VzZS1u199eoVHj58iKpVqwJApm/zvs/nn3+u837Tpk1ISkpChw4ddMrr4OAANzc3VVcIU9aTtba2RokSJWBmZoYOHToow0uUKAFra2v8/fffqb7fr18/nTsOAwYMQK5cufDLL78AAPbt24eEhAQMGTJEp8Fu3759YWlpiZ07d+pMz9jYGD179sxw+Y2NjZXpJiYm4tGjR8rt6LT+Pj179tRpqKq95a6dtzNnzuDGjRsYMmRIqivE2ivUjx8/xv79+9GhQwc8e/ZM+Xs8evQIPj4+uHr1qlJ9xdraGufPn8fVq1czPE/pSUxMxK+//orWrVujaNGiyvACBQqgS5cu+O233xAbG6vznb59+6aqMpGW2NhYWFhYZLgsKbeLuLg4PHz4ENWrV4eI4MyZMxmeTnqycl7Nzc3xv//9T3lvZGSEKlWqpLk+p5QV236/fv1S7YP27t2b6s7QqVOnEB0djS+++EKnzUOzZs3g7u6eajvJCGtra8TFxb2z2l16MrLMdu/ejYIFC6Jly5bKMBMTE+XuQlYwNzfX6R0qK/4mKaehvatdp04d/P3334iJiQHwT3ufHTt24PXr12lOZ/369bCyskLDhg119suVKlWCubl5pvfL2mpdKa/WA1CWw/u2UwsLi1TbRlri4uLw7Nkz2Nvbp3sHBEiuMvzo0SN07txZGda5c2f8+eefqaoOpzR48GDY2NggMDDwvWXp1asX8ufPD0dHRzRu3BgxMTFYuXIlKleuDCC5jcfGjRvRokULiIjO8vbx8UFMTIzy9//Q9TKtY8769etRsmRJuLu76/yWtt2C9m+rXU+2bt2KpKSkNKdvbW2NiIgInDx5Ms3Ps3q/bmNjg5cvX6Z5V5TSx2BBGVKlShV4e3vrvAAoJ3n169dH/vz5dV6//voroqOjlWk8fvwYgwcPhr29PUxNTZE/f36lOpD2IJTV3q5udPXqVYgI3NzcUpX34sWLOuX9ECYmJkr1AC0rKysUKlQoVTUPKyurNNtOuLm56bw3NzdHgQIFlFvZt27dAoBUvZQYGRmhaNGiyudaBQsW/KAeapKSkvD999/Dzc0NxsbGsLW1Rf78+XH27Nk0/z6FCxfWea89eGvnTVun9129h127dg0igrFjx6b6e4wbNw4AlL/JhAkT8PTpUxQvXhxly5bF8OHDcfbs2QzPX0oPHjzAixcv0uzxpWTJkkhKSkrV5ubtdSk9lpaWH9S95+3bt9GjRw/kzZsX5ubmyJ8/P+rUqQMga7aLrJzXtNZnGxubNNfnlLJi23dzc0u1D/L29tY5gQDS304AwN3dPdV2khFffPEFihcvjiZNmqBQoULo1asXdu/enaHvZmSZ3bp1C8WKFUs1nqur6weXNT3Pnz/XOZHOir/JkSNH4O3tDTMzM1hbWyN//vxKnXjtNOrUqYO2bdsiMDAQtra2aNWqFX788Ued+vVXr15FTEwM7OzsUu0Hnj9/nun9spb8fzVYLe1yeN92+uzZswxdJHB1dcXUqVOxf/9+dO7cGYmJiWmOt2rVKri4uCjVfK5du4ZixYohT548WL16dbrTt7KywpAhQ7Bt27b3XmwICAjA3r17sXnzZvj6+iImJkbnQtSDBw/w9OlTLFq0KNWy1oYC7fL+0PUyrWPO1atXcf78+VS/Vbx4cZ3f6tixI2rUqIE+ffrA3t4enTp1ws8//6wTMkaOHAlzc3NUqVIFbm5uGDhwoE5Vpazer2vXG/YK9WHYxoJU0W70K1euTLMru5S9aXTo0AFHjx7F8OHD4eHhAXNzcyQlJaFx48bpXqFIKb2NO72dOIBUPaAkJSVBo9Fg165d6V6RzYz0rnikN/ztA92/4UN7f5k8eTLGjh2LXr16YeLEicibNy8MDAwwZMiQNP8+WTFv2ukOGzYMPj4+aY6jPYjVrl0b169fx9atW/Hrr7/ihx9+wPfff4+QkJB3dteYVTK6PN3d3XHmzBncuXMHTk5O7xw3MTERDRs2xOPHjzFy5Ei4u7vDzMwMd+/eRY8ePTK0Xfwb0pvXzP7N1W77/xaNRpNm2d/ep9jZ2eGPP/7Anj17sGvXLuzatQs//vgjfH190+zGNCV97gO0IiIiEBMTo3NCqPZvcv36dTRo0ADu7u6YMWMGnJycYGRkhF9++QXff/+9Mg2NRoMNGzbg999/x/bt27Fnzx706tUL06dPx++//678rp2dXbon129ftMkobePpt4NvyZIlAeCdFyZu3bqF2NhYlCpVKkO/NWLECDx69AjTpk1D3759sWTJEp1jVmxsLLZv345Xr16luogEAGvWrEFQUFC6xzltW4vAwEDMnDkz3XKULVtWufDXunVrvHjxAn379kXNmjXh5OSk/F3+97//oXv37mlOIzPdEgNp7zeSkpJQtmxZzJgxI83vaPeRpqamOHToEA4cOICdO3di9+7dWLduHerXr49ff/0VhoaGKFmyJC5fvowdO3Zg9+7d2LhxI+bPn4+AgIAM3c3JaJm1njx5gjx58nxyPampxWBBqhQrVgxA8oFXuzNLy5MnTxAaGorAwEAEBAQow9Oq1pLejlV7RfztHpA+5ApksWLFICJwcXFRrphkF1evXkW9evWU98+fP8f9+/fRtGlTAFB6/Ll8+bLOVdqEhATcuHHjncs/pfSW74YNG1CvXj0sWbJEZ/jTp0/TbYj4Ltp146+//kq3bNr5yJ07d4bKnzdvXvTs2RM9e/bE8+fPUbt2bYwfP/6Dg0X+/PmRJ08eXL58OdVnly5dgoGBwXtDQXpatGiBtWvXYtWqVfD393/nuOfOncOVK1ewfPly+Pr6KsMzU+UmPf/mvGbEh2z7WSHldvJ2N5GXL19WPgeS9ylpVeNKa59iZGSEFi1aoEWLFkhKSsIXX3yBhQsXYuzYsarvLBQpUgQXLlyAiOhsn2n1spYZK1euBAAlvGfF/nj79u2Ij4/Htm3bdO5epldtqWrVqqhatSqCgoKwZs0adO3aFT/99BP69OmDYsWKYd++fahRo8Z7T+I+5Opx4cKFYWpqihs3bugML168OIoXL44tW7Zg1qxZad6VWLFiBQCgefPmGf69qVOn4vHjx/jhhx9gY2OD6dOnK59t2rQJr169woIFC1LtTy9fvoxvvvkGR44cSbMnOeCfuxbjx49PNxCkZcqUKdi8eTOCgoIQEhKC/Pnzw8LCAomJie/d52bFelmsWDH8+eefaNCgwXv/dgYGBmjQoAEaNGiAGTNmYPLkyRgzZgwOHDiglNXMzAwdO3ZEx44dkZCQgDZt2iAoKAj+/v5Zvq+7ceOGEkIp41gVilTx8fGBpaUlJk+enGb9WW1PTtqrdm9fpUvryou2H+m3A4SlpSVsbW1x6NAhneHz58/PcHnbtGkDQ0NDBAYGpiqLiPyr3V++z6JFi3SW4YIFC/DmzRul5xhvb28YGRlh9uzZOmVfsmQJYmJi0KxZswz9jpmZWZpPezU0NEy1TNavX5+qi86MqlixIlxcXDBz5sxUv6f9HTs7O9StWxcLFy7E/fv3U00jZU9gb/9tzM3N4erqmqrLwowwNDREo0aNsHXrVqWqGZDcW8qaNWtQs2bNd9aVfpd27dqhbNmyCAoKwrFjx1J9/uzZM6VHm7S2CxFJ1R2vGv/mvGb094GMbftZwdPTE3Z2dggJCdFZN3bt2oWLFy/qbCfFihXDpUuXdNazP//8M1VPMG+vewYGBspV3cysf2/z8fHB3bt3dXr9efXqFRYvXqx62vv378fEiRPh4uKCrl27Asia/XFa04iJicGPP/6oM96TJ09S/Y6HhweAf5Zdhw4dkJiYiIkTJ6b6/Tdv3uj8dnr7r7Tkzp0bnp6eOHXqVKrPAgIC8OTJE3z++eep7lCFh4dj6tSpKFOmDNq2bZuh39JauHAh2rVrhxkzZmDSpEnK8FWrVqFo0aL4/PPP0a5dO53XsGHDYG5u/s7qUACU9moTJkzIcHmKFSuGtm3bYtmyZYiMjIShoSHatm2LjRs34q+//ko1fsptISvWyw4dOuDu3btpfufly5dKT0xvP50cSL2evL0dGhkZoVSpUhARvH79Osv3dadPn0b16tUzPD4l4x0LUsXS0hILFixAt27dULFiRXTq1An58+fH7du3sXPnTtSoUQNz586FpaWl0hXr69evUbBgQfz666+priQBUJ4wOmbMGHTq1Am5c+dGixYtYGZmhj59+mDKlCno06cPPD09cejQoQ96gnGxYsUwadIk+Pv74+bNm2jdujUsLCxw48YNbN68Gf369cOwYcOybPl8iISEBDRo0AAdOnTA5cuXMX/+fNSsWVNpOJc/f374+/sjMDAQjRs3RsuWLZXxKleurNNA9F0qVaqEBQsWYNKkSXB1dYWdnR3q16+P5s2bY8KECejZsyeqV6+Oc+fOYfXq1anqsGeUgYEBFixYgBYtWsDDwwM9e/ZEgQIFcOnSJZw/fx579uwBkNwxQM2aNVG2bFn07dsXRYsWRVRUFI4dO4aIiAjlORqlSpVC3bp1lf7FT506hQ0bNmT6CdOTJk1S+k3/4osvkCtXLixcuBDx8fFpPmcgo3Lnzo1NmzbB29sbtWvXRocOHVCjRg3kzp0b58+fx5o1a2BjY4OgoCC4u7ujWLFiGDZsGO7evQtLS0ts3LjxvW0WPtS/Na8Z8SHbflbInTs3pk6dip49e6JOnTro3Lmz0t2ss7Mzhg4dqozbq1cvzJgxAz4+Pujduzeio6MREhKC0qVL6zTy7NOnDx4/foz69eujUKFCuHXrFubMmQMPD48suaLZv39/zJ07F507d8bgwYNRoEABrF69Wml8ntGr9Lt27cKlS5fw5s0bREVFYf/+/di7dy+KFCmCbdu2KdPLiv1xo0aNlLs4/fv3x/Pnz7F48WLY2dnpXCRYvnw55s+fj88++wzFihXDs2fPsHjxYlhaWip3Y+vUqYP+/fsjODgYf/zxBxo1aoTcuXPj6tWrWL9+PWbNmqU89C29/Vd6WrVqhTFjxiA2NlbnpLJr1644efIkZs2ahQsXLqBr166wsbHB6dOnsXTpUuTLlw8bNmz44CfIGxgYYPXq1YiJicHYsWORN29etG7dGgcOHMBXX32V5neMjY3h4+OD9evXY/bs2en+ppWVFQYPHvzB1X6GDx+On3/+GTNnzsSUKVMwZcoUHDhwAF5eXujbty9KlSqFx48f4/Tp09i3b59ykp8V62W3bt3w888/4/PPP8eBAwdQo0YNJCYm4tKlS/j555+xZ88eeHp6YsKECTh06BCaNWuGIkWKIDo6GvPnz0ehQoWUuziNGjWCg4MDatSoAXt7e1y8eBFz585Fs2bNlLtOWbWvCw8Px+PHj9GqVasPWtYEdjdL75aRbgxFkru68/HxESsrKzExMZFixYpJjx495NSpU8o4ERER8tlnn4m1tbVYWVlJ+/bt5d69e6m6XxURmThxohQsWFAMDAx0ujp88eKF9O7dW6ysrMTCwkI6dOgg0dHR6XY3m17XdRs3bpSaNWuKmZmZmJmZibu7uwwcOFAuX778wcsjrS4IRXS7C0ypSJEiOt2maqd58OBB6devn9jY2Ii5ubl07dpVHj16lOr7c+fOFXd3d8mdO7fY29vLgAEDUnXnmt5viyR3BdysWTOxsLAQAErXja9evZKvv/5aChQoIKamplKjRg05duxYqi45td0arl+/Xme66XUH/Ntvv0nDhg3FwsJCzMzMpFy5cqm6f7x+/br4+vqKg4OD5M6dWwoWLCjNmzeXDRs2KONMmjRJqlSpItbW1mJqairu7u4SFBSk00VvWtLrglVE5PTp0+Lj4yPm5uaSJ08eqVevnhw9elRnnIxuA2978uSJBAQESNmyZSVPnjxiYmIiZcqUEX9/f7l//74y3oULF8Tb21vMzc3F1tZW+vbtK3/++WeqZammu9msmNf01qm3u2ZNaz34kG3/be+aJ5H0t/V169ZJhQoVxNjYWPLmzStdu3aViIiIVN9ftWqVFC1aVIyMjMTDw0P27NmTap42bNggjRo1Ejs7OzEyMpLChQtL//79df6O6XU3m5FlJiLy999/S7NmzcTU1FTy588vX3/9tWzcuFEAyO+///7OZfR2t+BGRkbi4OAgDRs2lFmzZklsbGyq72TF/njbtm1Srlw5MTExEWdnZ5k6daosXbpUZ5zTp09L586dpXDhwmJsbCx2dnbSvHlznWOD1qJFi6RSpUpiamoqFhYWUrZsWRkxYoTcu3dPGSe9/Vd6oqKiJFeuXLJy5co0P9+yZYs0bNhQbGxsxNjYWFxdXeXrr79O89iRXnezaf2Nnz9/LlWrVhUDAwMJCgoSABIaGppuOZctW6bTvXh6033y5IlYWVml293s2/tlrbp164qlpaU8ffpURJKXy8CBA8XJyUly584tDg4O0qBBA1m0aJHO9zK6Xr7rmJOQkCBTp06V0qVLi7GxsdjY2EilSpUkMDBQYmJiREQkNDRUWrVqJY6OjmJkZCSOjo7SuXNnuXLlijKdhQsXSu3atSVfvnxibGwsxYoVk+HDhyvT0MqK/frIkSOlcOHCOl2jU8ZoRD5iCzIiSkX7UKiTJ0/C09NT38Uhomxi5syZGDp0KCIiIlCwYEF9FyfH6t27N65cuYLDhw/ruyj/Cf/19TI+Ph7Ozs4YNWrUex+ASamxjQUREZGevXz5Uuf9q1evsHDhQri5uf0nT94+pnHjxuHkyZN8inImfIrr5Y8//ojcuXOneg4WZQzbWBAREelZmzZtULhwYXh4eCAmJgarVq3CpUuX3tugl96vcOHCePXqlb6LkSN9iuvl559/zlChAoMFERGRnvn4+OCHH37A6tWrkZiYiFKlSuGnn35Cx44d9V00+oRxvaQPxTYWRERERESkGttYEBERERGRagwWRERERESkGttYpCEpKQn37t2DhYVFhh9MRERERET0XyMiePbsGRwdHWFg8O57EgwWabh37x6cnJz0XQwiIiIiomzhzp07KFSo0DvHYbBIg/bR8Hfu3IGlpaWeS0NEREREpB+xsbFwcnJSzo/fhcEiDdrqT5aWlgwWRERERPTJy0jzADbeJiIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1bJFsJg3bx6cnZ1hYmICLy8vnDhxIt1xN23aBE9PT1hbW8PMzAweHh5YuXKlzjg9evSARqPReTVu3Pjfng0iIiIiok9WLn0XYN26dfDz80NISAi8vLwwc+ZM+Pj44PLly7Czs0s1ft68eTFmzBi4u7vDyMgIO3bsQM+ePWFnZwcfHx9lvMaNG+PHH39U3hsbG3+U+SEiIiIi+hRpRET0WQAvLy9UrlwZc+fOBQAkJSXByckJgwYNwqhRozI0jYoVK6JZs2aYOHEigOQ7Fk+fPsWWLVsyVabY2FhYWVkhJiYGlpaWmZoGEREREVFO9yHnxXqtCpWQkIDw8HB4e3srwwwMDODt7Y1jx4699/sigtDQUFy+fBm1a9fW+SwsLAx2dnYoUaIEBgwYgEePHqU7nfj4eMTGxuq8iIiIiIgo4/RaFerhw4dITEyEvb29znB7e3tcunQp3e/FxMSgYMGCiI+Ph6GhIebPn4+GDRsqnzdu3Bht2rSBi4sLrl+/jtGjR6NJkyY4duwYDA0NU00vODgYgYGBWTdjRERERESfGL23scgMCwsL/PHHH3j+/DlCQ0Ph5+eHokWLom7dugCATp06KeOWLVsW5cqVQ7FixRAWFoYGDRqkmp6/vz/8/PyU97GxsXBycvrX54OIiIiI6L9Cr8HC1tYWhoaGiIqK0hkeFRUFBweHdL9nYGAAV1dXAICHhwcuXryI4OBgJVi8rWjRorC1tcW1a9fSDBbGxsbZrnG3JlCj7yJkCzJOr02AiIiIiCiD9NrGwsjICJUqVUJoaKgyLCkpCaGhoahWrVqGp5OUlIT4+Ph0P4+IiMCjR49QoEABVeUlIiIiIqK06b0qlJ+fH7p37w5PT09UqVIFM2fORFxcHHr27AkA8PX1RcGCBREcHAwguT2Ep6cnihUrhvj4ePzyyy9YuXIlFixYAAB4/vw5AgMD0bZtWzg4OOD69esYMWIEXF1ddbqjJSIiIiKirKP3YNGxY0c8ePAAAQEBiIyMhIeHB3bv3q006L59+zYMDP65sRIXF4cvvvgCERERMDU1hbu7O1atWoWOHTsCAAwNDXH27FksX74cT58+haOjIxo1aoSJEydmu+pORERERET/FXp/jkV2lB2eY8E2FsnYxoKIiIhIf3LMcyyIiIiIiOi/gcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDW9P3mbiIiI9I8PZk3GB7MSZR7vWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkWrYIFvPmzYOzszNMTEzg5eWFEydOpDvupk2b4OnpCWtra5iZmcHDwwMrV67UGUdEEBAQgAIFCsDU1BTe3t64evXqvz0bRERERESfLL0Hi3Xr1sHPzw/jxo3D6dOnUb58efj4+CA6OjrN8fPmzYsxY8bg2LFjOHv2LHr27ImePXtiz549yjjTpk3D7NmzERISguPHj8PMzAw+Pj549erVx5otIiIiIqJPikZERJ8F8PLyQuXKlTF37lwAQFJSEpycnDBo0CCMGjUqQ9OoWLEimjVrhokTJ0JE4OjoiK+//hrDhg0DAMTExMDe3h7Lli1Dp06d3ju92NhYWFlZISYmBpaWlpmfORU0gRq9/G52I+P0unoSEX0yeNxJxuMOka4POS/W6x2LhIQEhIeHw9vbWxlmYGAAb29vHDt27L3fFxGEhobi8uXLqF27NgDgxo0biIyM1JmmlZUVvLy80p1mfHw8YmNjdV5ERERERJRxeg0WDx8+RGJiIuzt7XWG29vbIzIyMt3vxcTEwNzcHEZGRmjWrBnmzJmDhg0bAoDyvQ+ZZnBwMKysrJSXk5OTmtkiIiIiIvrk6L2NRWZYWFjgjz/+wMmTJxEUFAQ/Pz+EhYVlenr+/v6IiYlRXnfu3Mm6whIRERERfQJy6fPHbW1tYWhoiKioKJ3hUVFRcHBwSPd7BgYGcHV1BQB4eHjg4sWLCA4ORt26dZXvRUVFoUCBAjrT9PDwSHN6xsbGMDY2Vjk3RERERESfLr3esTAyMkKlSpUQGhqqDEtKSkJoaCiqVauW4ekkJSUhPj4eAODi4gIHBwedacbGxuL48eMfNE0iIiIiIso4vd6xAAA/Pz90794dnp6eqFKlCmbOnIm4uDj07NkTAODr64uCBQsiODgYQHJ7CE9PTxQrVgzx8fH45ZdfsHLlSixYsAAAoNFoMGTIEEyaNAlubm5wcXHB2LFj4ejoiNatW+trNomIiIiI/tP0Hiw6duyIBw8eICAgAJGRkfDw8MDu3buVxte3b9+GgcE/N1bi4uLwxRdfICIiAqampnB3d8eqVavQsWNHZZwRI0YgLi4O/fr1w9OnT1GzZk3s3r0bJiYmH33+iIiIiIg+BXp/jkV2xOdYZB/sT5yI6OPgcScZjztEunLMcyyIiIiIiOi/gcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVskWwmDdvHpydnWFiYgIvLy+cOHEi3XEXL16MWrVqwcbGBjY2NvD29k41fo8ePaDRaHRejRs3/rdng4iIiIjok6X3YLFu3Tr4+flh3LhxOH36NMqXLw8fHx9ER0enOX5YWBg6d+6MAwcO4NixY3ByckKjRo1w9+5dnfEaN26M+/fvK6+1a9d+jNkhIiIiIvok6T1YzJgxA3379kXPnj1RqlQphISEIE+ePFi6dGma469evRpffPEFPDw84O7ujh9++AFJSUkIDQ3VGc/Y2BgODg7Ky8bG5mPMDhERERHRJ0mvwSIhIQHh4eHw9vZWhhkYGMDb2xvHjh3L0DRevHiB169fI2/evDrDw8LCYGdnhxIlSmDAgAF49OhRutOIj49HbGyszouIiIiIiDJOr8Hi4cOHSExMhL29vc5we3t7REZGZmgaI0eOhKOjo044ady4MVasWIHQ0FBMnToVBw8eRJMmTZCYmJjmNIKDg2FlZaW8nJycMj9TRERERESfoFz6LoAaU6ZMwU8//YSwsDCYmJgowzt16qT8v2zZsihXrhyKFSuGsLAwNGjQINV0/P394efnp7yPjY1luCAiIiIi+gB6vWNha2sLQ0NDREVF6QyPioqCg4PDO7/73XffYcqUKfj1119Rrly5d45btGhR2Nra4tq1a2l+bmxsDEtLS50XERERERFlnF6DhZGRESpVqqTT8FrbELtatWrpfm/atGmYOHEidu/eDU9Pz/f+TkREBB49eoQCBQpkSbmJiIiIiEiX3nuF8vPzw+LFi7F8+XJcvHgRAwYMQFxcHHr27AkA8PX1hb+/vzL+1KlTMXbsWCxduhTOzs6IjIxEZGQknj9/DgB4/vw5hg8fjt9//x03b95EaGgoWrVqBVdXV/j4+OhlHomIiIiI/uv03saiY8eOePDgAQICAhAZGQkPDw/s3r1badB9+/ZtGBj8k38WLFiAhIQEtGvXTmc648aNw/jx42FoaIizZ89i+fLlePr0KRwdHdGoUSNMnDgRxsbGH3XeiIiIiIg+FRoREX0XIruJjY2FlZUVYmJi9NbeQhOo0cvvZjcyjqsnEdHHwONOMh53iHR9yHmx3qtCERERERFRzsdgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkWqaDxcqVK1GjRg04Ojri1q1bAICZM2di69atWVY4IiIiIiLKGTIVLBYsWAA/Pz80bdoUT58+RWJiIgDA2toaM2fOzMryERERERFRDpCpYDFnzhwsXrwYY8aMgaGhoTLc09MT586dy7LCERERERFRzpCpYHHjxg1UqFAh1XBjY2PExcWpLhQREREREeUsmQoWLi4u+OOPP1IN3717N0qWLKm2TERERERElMPkysyX/Pz8MHDgQLx69QoighMnTmDt2rUIDg7GDz/8kNVlJCIiIiKibC5TwaJPnz4wNTXFN998gxcvXqBLly5wdHTErFmz0KlTp6wuIxERERERZXOZChYA0LVrV3Tt2hUvXrzA8+fPYWdnl5XlIiIiIiKiHCRTweLGjRt48+YN3NzckCdPHuTJkwcAcPXqVeTOnRvOzs5ZWUYiIiIiIsrmMtV4u0ePHjh69Giq4cePH0ePHj3UlomIiIiIiHKYTAWLM2fOoEaNGqmGV61aNc3eot5n3rx5cHZ2homJCby8vHDixIl0x128eDFq1aoFGxsb2NjYwNvbO9X4IoKAgAAUKFAApqam8Pb2xtWrVz+4XERERERElDGZChYajQbPnj1LNTwmJkZ5CndGrVu3Dn5+fhg3bhxOnz6N8uXLw8fHB9HR0WmOHxYWhs6dO+PAgQM4duwYnJyc0KhRI9y9e1cZZ9q0aZg9ezZCQkJw/PhxmJmZwcfHB69evfqwGSUiIiIiogzRiIh86JdatGgBU1NTrF27VnnydmJiIjp27Ii4uDjs2rUrw9Py8vJC5cqVMXfuXABAUlISnJycMGjQIIwaNeq9309MTISNjQ3mzp0LX19fiAgcHR3x9ddfY9iwYQCSA4+9vT2WLVuWoV6rYmNjYWVlhZiYGFhaWmZ4XrKSJlCjl9/NbmTcB6+eRESUCTzuJONxh0jXh5wXZ6rx9tSpU1G7dm2UKFECtWrVAgAcPnwYsbGx2L9/f4ank5CQgPDwcPj7+yvDDAwM4O3tjWPHjmVoGi9evMDr16+RN29eAMkNyyMjI+Ht7a2MY2VlBS8vLxw7dozd4RIRERER/QsyVRWqVKlSOHv2LDp06IDo6Gg8e/YMvr6+uHTpEsqUKZPh6Tx8+BCJiYmwt7fXGW5vb4/IyMgMTWPkyJFwdHRUgoT2ex8yzfj4eMTGxuq8iIiIiIgo4zL9HAtHR0dMnjw5K8vywaZMmYKffvoJYWFhMDExyfR0goODERgYmIUlIyIiIiL6tGQ6WDx9+hQnTpxAdHQ0kpKSdD7z9fXN0DRsbW1haGiIqKgoneFRUVFwcHB453e/++47TJkyBfv27UO5cuWU4drvRUVFoUCBAjrT9PDwSHNa/v7+8PPzU97HxsbCyckpQ/NARERERESZDBbbt29H165d8fz5c1haWkKj+afBl0ajyXCwMDIyQqVKlRAaGorWrVsDSG68HRoaii+//DLd702bNg1BQUHYs2cPPD09dT5zcXGBg4MDQkNDlSARGxuL48ePY8CAAWlOz9jYGMbGxhkqMxERERERpZapYPH111+jV69emDx5svLU7czy8/ND9+7d4enpiSpVqmDmzJmIi4tDz549ASTf/ShYsCCCg4MBJDccDwgIwJo1a+Ds7Ky0mzA3N4e5uTk0Gg2GDBmCSZMmwc3NDS4uLhg7diwcHR2V8EJERERERFkrU8Hi7t27+Oqrr1SHCgDo2LEjHjx4gICAAERGRsLDwwO7d+9WGl/fvn0bBgb/tDFfsGABEhIS0K5dO53pjBs3DuPHjwcAjBgxAnFxcejXrx+ePn2KmjVrYvfu3araYRARERERUfoy9RyLNm3aoFOnTujQocO/USa943Mssg/2J05E9HHwuJOMxx0iXf/6cyyaNWuG4cOH48KFCyhbtixy586t83nLli0zM1kiIiIiIsqhMhUs+vbtCwCYMGFCqs80Gg0SExPVlYqIiIiIiHKUTAWLt7uXJSIiIiKiT1umnrxNRERERESUUqYfkBcXF4eDBw/i9u3bSEhI0Pnsq6++Ul0wIiIiIiLKOTIVLM6cOYOmTZvixYsXiIuLQ968efHw4UPkyZMHdnZ2DBZERERERJ+YTFWFGjp0KFq0aIEnT57A1NQUv//+O27duoVKlSrhu+++y+oyEhERERFRNpepYPHHH3/g66+/hoGBAQwNDREfHw8nJydMmzYNo0ePzuoyEhERERFRNpepYJE7d27ladh2dna4ffs2AMDKygp37tzJutIREREREVGOkKk2FhUqVMDJkyfh5uaGOnXqICAgAA8fPsTKlStRpkyZrC4jERERERFlc5m6YzF58mQUKFAAABAUFAQbGxsMGDAADx48wMKFC7O0gERERERElP1l6o6Fp6en8n87Ozvs3r07ywpEREREREQ5T6buWNSvXx9Pnz5NNTw2Nhb169dXWyYiIiIiIsphMhUswsLCUj0UDwBevXqFw4cPqy4UERERERHlLB9UFers2bPK/y9cuIDIyEjlfWJiInbv3o2CBQtmXemIiIiIiChH+KBg4eHhAY1GA41Gk2aVJ1NTU8yZMyfLCkdERERERDnDBwWLGzduQERQtGhRnDhxAvnz51c+MzIygp2dHQwNDbO8kERERERElL19ULAoUqQIXr9+je7duyNfvnwoUqTIv1UuIiIiIiLKQT648Xbu3LmxefPmf6MsRERERESUQ2WqV6hWrVphy5YtWVwUIiIiIiLKqTL1gDw3NzdMmDABR44cQaVKlWBmZqbz+VdffZUlhSMiIiIiopwhU8FiyZIlsLa2Rnh4OMLDw3U+02g0DBZERERERJ+YTAWLGzduZHU5iIiIiIgoB8tUG4uURAQikhVlISIiIiKiHCrTwWLFihUoW7YsTE1NYWpqinLlymHlypVZWTYiIiIiIsohMlUVasaMGRg7diy+/PJL1KhRAwDw22+/4fPPP8fDhw8xdOjQLC0kERERERFlb5kKFnPmzMGCBQvg6+urDGvZsiVKly6N8ePHM1gQEREREX1iMlUV6v79+6hevXqq4dWrV8f9+/dVF4qIiIiIiHKWTAULV1dX/Pzzz6mGr1u3Dm5ubqoLRUREREREOUumqkIFBgaiY8eOOHTokNLG4siRIwgNDU0zcBARERER0X9bpu5YtG3bFsePH4etrS22bNmCLVu2wNbWFidOnMBnn32W1WUkIiIiIqJsLlN3LACgUqVKWLVqVVaWhYiIiIiIcqhMB4vExERs3rwZFy9eBACUKlUKrVq1Qq5cmZ4kERERERHlUJlKAefPn0fLli0RGRmJEiVKAACmTp2K/PnzY/v27ShTpkyWFpKIiIiIiLK3TLWx6NOnD0qXLo2IiAicPn0ap0+fxp07d1CuXDn069cvq8tIRERERETZXKbuWPzxxx84deoUbGxslGE2NjYICgpC5cqVs6xwRERERESUM2TqjkXx4sURFRWVanh0dDRcXV1VF4qIiIiIiHKWTAWL4OBgfPXVV9iwYQMiIiIQERGBDRs2YMiQIZg6dSpiY2OVFxERERER/fdlqipU8+bNAQAdOnSARqMBAIgIAKBFixbKe41Gg8TExKwoJxERERERZWOZChYHDhzI6nIQEREREVEOlqlgUadOnawuBxERERER5WCZfprdq1evcPbsWURHRyMpKUnns5YtW6ouGBERERER5RyZCha7d++Gr68vHj58mOoztqsgIiIiIvr0ZKpXqEGDBqF9+/a4f/8+kpKSdF4MFUREREREn55MBYuoqCj4+fnB3t4+q8tDREREREQ5UKaCRbt27RAWFpbFRSEiIiIiopwqU20s5s6di/bt2+Pw4cMoW7YscufOrfP5V199lSWFIyIiIiKinCFTwWLt2rX49ddfYWJigrCwMOUheUBy420GCyIiIiKiT0umgsWYMWMQGBiIUaNGwcAgU7WpiIiIiIjoPyRTqSAhIQEdO3ZkqCAiIiIiIgCZDBbdu3fHunXrsrosRERERESUQ2UqWCQmJmLatGmoU6cOBg0aBD8/P53Xh5g3bx6cnZ1hYmICLy8vnDhxIt1xz58/j7Zt28LZ2RkajQYzZ85MNc748eOh0Wh0Xu7u7h86i0RERERE9AEy1cbi3LlzqFChAgDgr7/+yvSPr1u3Dn5+fggJCYGXlxdmzpwJHx8fXL58GXZ2dqnGf/HiBYoWLYr27dtj6NCh6U63dOnS2Ldvn/I+V65MzSYREREREWVQps64Dxw4kCU/PmPGDPTt2xc9e/YEAISEhGDnzp1YunQpRo0alWr8ypUro3LlygCQ5udauXLlgoODQ5aUkYiIiIiI3u+DgkWbNm3eO45Go8HGjRvfO15CQgLCw8Ph7++vDDMwMIC3tzeOHTv2IcVK5erVq3B0dISJiQmqVauG4OBgFC5cWNU0iYiIiIgofR8ULKysrLLshx8+fIjExETY29vrDLe3t8elS5cyPV0vLy8sW7YMJUqUwP379xEYGIhatWrhr7/+goWFRZrfiY+PR3x8vPI+NjY2079PRERERPQp+qBg8eOPP/5b5cgyTZo0Uf5frlw5eHl5oUiRIvj555/Ru3fvNL8THByMwMDAj1VEIiIiIqL/HL09iMLW1haGhoaIiorSGR4VFZWl7SOsra1RvHhxXLt2Ld1x/P39ERMTo7zu3LmTZb9PRERERPQp0FuwMDIyQqVKlRAaGqoMS0pKQmhoKKpVq5Zlv/P8+XNcv34dBQoUSHccY2NjWFpa6ryIiIiIiCjj9NoPq5+fH7p37w5PT09UqVIFM2fORFxcnNJLlK+vLwoWLIjg4GAAyQ2+L1y4oPz/7t27+OOPP2Bubg5XV1cAwLBhw9CiRQsUKVIE9+7dw7hx42BoaIjOnTvrZyaJiIiIiD4Beg0WHTt2xIMHDxAQEIDIyEh4eHhg9+7dSoPu27dvw8Dgn5sq9+7dU56fAQDfffcdvvvuO9SpUwdhYWEAgIiICHTu3BmPHj1C/vz5UbNmTfz+++/Inz//R503IiIiIqJPiUZERN+FyG5iY2NhZWWFmJgYvVWL0gRq9PK72Y2M4+pJRPQx8LiTjMcdIl0fcl6stzYWRERERET038FgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWq59F0Aon+bJlCj7yJkCzJO9F0EIiIi+g/jHQsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOwICIiIiIi1RgsiIiIiIhINQYLIiIiIiJSjcGCiIiIiIhUY7AgIiIiIiLVGCyIiIiIiEg1BgsiIiIiIlKNwYKIiIiIiFRjsCAiIiIiItX0HizmzZsHZ2dnmJiYwMvLCydOnEh33PPnz6Nt27ZwdnaGRqPBzJkzVU+TiIiIiIjU02uwWLduHfz8/DBu3DicPn0a5cuXh4+PD6Kjo9Mc/8WLFyhatCimTJkCBweHLJkmERERERGpp9dgMWPGDPTt2xc9e/ZEqVKlEBISgjx58mDp0qVpjl+5cmV8++236NSpE4yNjbNkmkREREREpJ7egkVCQgLCw8Ph7e39T2EMDODt7Y1jx45lm2kSEREREdH75dLXDz98+BCJiYmwt7fXGW5vb49Lly591GnGx8cjPj5eeR8bG5up3yciIiIi+lTpvfF2dhAcHAwrKyvl5eTkpO8iERERERHlKHoLFra2tjA0NERUVJTO8KioqHQbZv9b0/T390dMTIzyunPnTqZ+n4iIiIjoU6W3YGFkZIRKlSohNDRUGZaUlITQ0FBUq1bto07T2NgYlpaWOi8iIiIiIso4vbWxAAA/Pz90794dnp6eqFKlCmbOnIm4uDj07NkTAODr64uCBQsiODgYQHLj7AsXLij/v3v3Lv744w+Ym5vD1dU1Q9MkIiIiIqKsp9dg0bFjRzx48AABAQGIjIyEh4cHdu/erTS+vn37NgwM/rmpcu/ePVSoUEF5/9133+G7775DnTp1EBYWlqFpEhERERFR1tOIiOi7ENlNbGwsrKysEBMTo7dqUZpAjV5+N7uRcepXTy7LZFmxLInov4v7ymTcVxLp+pDzYvYKRUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESq5dJ3AYiIPkWaQI2+i5AtyDjRdxGIiCiL8I4FERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpFoufReAiIiIiCgtmkCNvouQLcg40XcRMiRb3LGYN28enJ2dYWJiAi8vL5w4ceKd469fvx7u7u4wMTFB2bJl8csvv+h83qNHD2g0Gp1X48aN/81ZICIiIiL6pOk9WKxbtw5+fn4YN24cTp8+jfLly8PHxwfR0dFpjn/06FF07twZvXv3xpkzZ9C6dWu0bt0af/31l854jRs3xv3795XX2rVrP8bsEBERERF9kvQeLGbMmIG+ffuiZ8+eKFWqFEJCQpAnTx4sXbo0zfFnzZqFxo0bY/jw4ShZsiQmTpyIihUrYu7cuTrjGRsbw8HBQXnZ2Nh8jNkhIiIiIvok6TVYJCQkIDw8HN7e3sowAwMDeHt749ixY2l+59ixYzrjA4CPj0+q8cPCwmBnZ4cSJUpgwIABePToUbrliI+PR2xsrM6LiIiIiIgyTq/B4uHDh0hMTIS9vb3OcHt7e0RGRqb5ncjIyPeO37hxY6xYsQKhoaGYOnUqDh48iCZNmiAxMTHNaQYHB8PKykp5OTk5qZwzIiIiIqJPy3+yV6hOnTop/y9btizKlSuHYsWKISwsDA0aNEg1vr+/P/z8/JT3sbGxDBdERERERB9Ar3csbG1tYWhoiKioKJ3hUVFRcHBwSPM7Dg4OHzQ+ABQtWhS2tra4du1amp8bGxvD0tJS50VERERERBmn12BhZGSESpUqITQ0VBmWlJSE0NBQVKtWLc3vVKtWTWd8ANi7d2+64wNAREQEHj16hAIFCmRNwYmIiIiISIfee4Xy8/PD4sWLsXz5cly8eBEDBgxAXFwcevbsCQDw9fWFv7+/Mv7gwYOxe/duTJ8+HZcuXcL48eNx6tQpfPnllwCA58+fY/jw4fj9999x8+ZNhIaGolWrVnB1dYWPj49e5pGIiIiI6L9O720sOnbsiAcPHiAgIACRkZHw8PDA7t27lQbat2/fhoHBP/mnevXqWLNmDb755huMHj0abm5u2LJlC8qUKQMAMDQ0xNmzZ7F8+XI8ffoUjo6OaNSoESZOnAhjY2O9zCMRERER0X+d3oMFAHz55ZfKHYe3hYWFpRrWvn17tG/fPs3xTU1NsWfPnqwsHhERERERvYfeq0IREREREVHOx2BBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKpli+5miShn0ARq9F2EbEHGib6LQERElO3wjgUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREamWS98FICIiIvov0QRq9F2EbEHGib6LQB8Z71gQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpBqDBRERERERqcZgQUREREREqjFYEBERERGRagwWRERERESkGoMFERERERGpxmBBRERERESqMVgQEREREZFqDBZERERERKQagwUREREREanGYEFERERERKoxWBARERERkWoMFkREREREpFq2CBbz5s2Ds7MzTExM4OXlhRMnTrxz/PXr18Pd3R0mJiYoW7YsfvnlF53PRQQBAQEoUKAATE1N4e3tjatXr/6bs0BERERE9EnLpe8CrFu3Dn5+fggJCYGXlxdmzpwJHx8fXL58GXZ2dqnGP3r0KDp37ozg4GA0b94ca9asQevWrXH69GmUKVMGADBt2jTMnj0by5cvh4uLC8aOHQsfHx9cuHABJiYmH3sWiYjoX6IJ1Oi7CNmCjBN9F4GISP93LGbMmIG+ffuiZ8+eKFWqFEJCQpAnTx4sXbo0zfFnzZqFxo0bY/jw4ShZsiQmTpyIihUrYu7cuQCS71bMnDkT33zzDVq1aoVy5cphxYoVuHfvHrZs2fIR54yIiIiI6NOh1zsWCQkJCA8Ph7+/vzLMwMAA3t7eOHbsWJrfOXbsGPz8/HSG+fj4KKHhxo0biIyMhLe3t/K5lZUVvLy8cOzYMXTq1CnVNOPj4xEfH6+8j4mJAQDExsZmet5Ue6W/n85OsuRvwGUJgMsyK3FZZh3Vy5LLEQDXyazEZZl1uCyzjj7PSbW/LfL+O6N6DRYPHz5EYmIi7O3tdYbb29vj0qVLaX4nMjIyzfEjIyOVz7XD0hvnbcHBwQgMDEw13MnJKWMzQv8aqylW+i7CfwaXZdbhssw6XJZZg8sx63BZZh0uy6yTHZbls2fPYGX17nLovY1FduDv769zFyQpKQmPHz9Gvnz5oNF8mvV3Y2Nj4eTkhDt37sDS0lLfxcnRuCyzDpdl1uGyzBpcjlmHyzLrcFlmHS7L5DsVz549g6Oj43vH1WuwsLW1haGhIaKionSGR0VFwcHBIc3vODg4vHN87b9RUVEoUKCAzjgeHh5pTtPY2BjGxsY6w6ytrT9kVv6zLC0tP9kNKatxWWYdLsusw2WZNbgcsw6XZdbhssw6n/qyfN+dCi29Nt42MjJCpUqVEBoaqgxLSkpCaGgoqlWrluZ3qlWrpjM+AOzdu1cZ38XFBQ4ODjrjxMbG4vjx4+lOk4iIiIiI1NF7VSg/Pz90794dnp6eqFKlCmbOnIm4uDj07NkTAODr64uCBQsiODgYADB48GDUqVMH06dPR7NmzfDTTz/h1KlTWLRoEQBAo9FgyJAhmDRpEtzc3JTuZh0dHdG6dWt9zSYRERER0X+a3oNFx44d8eDBAwQEBCAyMhIeHh7YvXu30vj69u3bMDD458ZK9erVsWbNGnzzzTcYPXo03NzcsGXLFuUZFgAwYsQIxMXFoV+/fnj69Clq1qyJ3bt38xkWH8DY2Bjjxo1LVUWMPhyXZdbhssw6XJZZg8sx63BZZh0uy6zDZflhNJKRvqOIiIiIiIjeQe8PyCMiIiIiopyPwYKIiIiIiFRjsCAiIiIiItUYLIiIiIiISDUGCyIiIiIiUo3BgoiIiIiIVGOw+IQlJSXpuwg5VspemtljszpcfllDuxxv3ryJiIgIPZeGiPtJok8Rg8UnRLtjv3HjBl68eKHz4EHKuKSkJGg0GuV9QkKCHkuTs4kINBoNwsLCsGLFCn0XJ8fSLsctW7agXbt22LlzJx4/fqzvYuVYPAlW7+39JC9kqcf1MmuktRy5fmYdnll+IrQnHlu3bkX79u0xa9YsvH79Wt/FynGSkpKUQDZr1ix07doVNWvWxHfffYfr16/ruXQ5i3ad3LRpE9q3b4+jR4/ixo0b+i5WjqTRaLB9+3Z06dIFXbt2RevWrZE3b16dcXhSkjEpT4hfvHihc+GAyzDjtPvJ6dOno3379mjWrBkWLlyIR48e6blkOZN2fxkaGoqxY8eiVatW2LBhAy5duqTvouUoKbfvO3fu4MaNG3j9+jUvtGYhLslPhEajwc6dO9GxY0f06dMH7dq1Q+7cufVdrBxHu/Px9/fH1KlTUbJkSQwYMAAjRozA5MmTeZX4A2g0Ghw6dAjdu3fHt99+i5CQELi4uKQajydz7xcdHY1JkyZh0qRJGDp0KKysrPDgwQNs2LABBw4cAACdq8eUPu02HhwcDB8fH7Rp0wZz584FkLwMuT6+W8orv+PGjcOkSZOQL18+ODo6YtCgQRg6dCguXLigxxLmTBqNBps3b0br1q3x5MkT2NraIigoCEOGDEFkZKS+i5cjiIiyfQcGBqJFixZo0KABypQpg2XLljH0ZpFc+i4AfRzPnz/HwoULMWLECHz++efK8JRX4CljTp48iQ0bNmDjxo2oVq0awsPDYWBggNq1a6e6SkzvduTIEXz22Wfo0aMHYmJicPLkSSxfvhwajQbt27dH8+bNeUKcAWZmZjAyMoKBgQEePXqE6dOn47fffsOVK1fw/PlzzJw5E3369NF3MbO1lPvCGTNmYPr06RgwYABu3ryJsWPH4tatW/j222+VcMH1Mm3aZXjlyhUkJiZi69atqF27NgCgZ8+e6NChA0xMTLBw4UIuwwzQrms3b95EQEAApk+fjn79+iEuLg729vZo0qQJHBwc9F3MHEG7vgUFBWH+/PlYsmQJGjVqhEaNGmHChAmoWrUq8uXLp+dS5nw8o/xEiAjOnz+f6sRXexDQ3u7n1bj3e/nyJWxtbVGtWjWsX78edevWxdy5c9G9e3fExsbi8OHD+i5itpZyHXv27Bm2bNmCo0ePwtfXF9999x2ePn2Ka9euYcKECYiJidFjSXOOhIQEODo6Yv369ShYsCAuXbqErl274vjx42jatClOnTql7yJme9p94fHjx5EnTx6sWrUKEydOxLx58/Dtt99i1qxZGD58OADeuXif7du3w93dHYsXL0auXMnXLxMTE1GrVi2sWrUKS5Yswf79+/Vcyuxrw4YN2LVrF4B/Toa1x+iuXbvi2rVrcHd3R5cuXTB58mQAwLFjx/D06VO9lDc7i4uLU/6flJSEmJgY7Nu3DzNmzEDz5s0RGhqKM2fOYMSIEXB3d2dbiyzAYPEflvLAl5CQAAcHBzx9+hRJSUk6n509exZTp07Fy5cveQXpLWntZAwNDREZGYl58+ahb9++mDZtmnIX6Pjx45gyZQquXbv2sYua7WnXuZTLdPTo0ahcuTJat24NCwsLDBs2DNu3b8fChQvx/PlzHijToF2OFy5cwKFDh3Dt2jXY2Njg+++/h7+/P3744QesXbsW/fv3R5EiRSAiMDc313Opc4YjR46gWrVq8Pf3h4mJCQDA0tISXbp0wYIFCzBnzhyMHDkSAKuWpfT2ftLZ2Rl9+vTB06dPcefOHWWcpKQk1KhRAyVKlMDVq1f1UdRs786dOxg/fjzmz5+vE76ePn0KAwMD3Lp1C40aNULjxo0REhICAAgPD8eyZctw9+5dfRU7W2rTpg2++eYbPHnyBEDyxYOXL18iIiICPj4+2L9/Pzp06ICpU6fi888/x4sXLzB37lzcu3dPzyXP4YT+c5KSkkRE5MWLFzrDhw8fLubm5rJnzx5JTExUho8ZM0bq1KkjDx8+/KjlzO60y1FEZOnSpXLixAl58+aNvHr1Sjp27Ci5cuWSMWPGKOO8evVKWrRoIe3bt9dZvvTPstyzZ4907dpVRo4cKVu2bFE+v3Llis74I0aMkKpVq8qTJ08+ZjFzjM2bN4uZmZm4urpKrly5ZPbs2fLy5UudcR49eiSjRo0SW1tbuXjxop5KmrNERERIUFCQmJuby4QJE3Q+e/HihSxZskQ0Go3MnTtXTyXM3jZt2qRs6xcvXpTOnTuLiYmJHDhwQBnn2bNn4uLiIosWLdJTKbO/sLAwqVWrlnz22WeyZ88eZXjNmjVFo9HI559/rjO+dn8ZGRn5sYuarc2aNUs0Go2MGzdOHj9+rAxv2LChNGjQQMzNzWXJkiXK8Fu3bknNmjXl559/1kdx/zMYLP5jtDv1HTt2SIMGDeSzzz6TsWPHKp936tRJzMzMZNiwYRIQECC9e/cWCwsL+eOPP/RV5GwpZTB49OiRGBoaio+Pj5w5c0ZEkk+Q69SpIxUrVpRly5bJ/PnzpVGjRlKmTBl5/fp1qmmQyP79+8XU1FQ6duwo5cuXl4oVK8rEiRN1xgkNDZUhQ4aItbW1sqzpH4mJifLkyROpVauWLFy4UK5fvy7Tpk0TjUYjEyZMUA6eP//8s3Tq1EmKFi0qp0+f1nOps6f0ts/o6GgZP368mJiYyIwZM3Q+e/78uWzfvl3Zxukft2/fFo1GI5999plyHLp8+bJ06dJFcufOLaNHj5apU6dKixYtpGTJklyGaUhMTFTWy127dkmtWrWkdevWEhoaKiIif/75p1SsWFE8PDzk+PHjsm3bNvHz8xMLCwv5888/9Vn0bOfNmzciIvLjjz+KRqOR8ePHy71790REZPny5eLi4iKNGzdWxn/+/Lk0bdpU6tWrp3yXMofB4j/o8OHDYmRkJAMHDpTOnTuLk5OTtG7dWvl83Lhx0qpVK6lQoYJ06tRJzp49q8fSZm8jRoyQzz//XDw8PMTExES8vLzkr7/+EhGRX3/9Vfr06SP58uWTevXqSffu3SUhIUFEhAfNNCxcuFBmzpwpIiJ///23fPPNN+Lu7i6TJk0SEZHIyEjx9/eXGjVqcJ18S8q7kC9evJDRo0fr3GGcP3++aDQamThxoiQkJEh0dLQsXLhQ/v77b30VOVtLGSpWrVolkydPlsGDB8vZs2fl1atXEhcXJ4GBgWJhYZEqXGh96tt4yju6WmFhYWJvby/t2rXTCRe+vr6SK1cuadasmWzZskW5u8YTOF3aZbZlyxYZPHiwlClTRgwNDaV+/fpy8OBBERE5ceKE1KpVSxwdHaVkyZJSt25dXhh8S8rt+/Hjx9KvXz8xMTGRiRMnyosXL+TZs2cyatQocXNzEy8vL+ncubNUq1ZNypUrpxzDuW5mHoPFf8ylS5dk586dysEwLi5OduzYIfny5ZOWLVsq4z1//lxevXolr1690ldRs73Zs2eLjY2NHD9+XC5duiTh4eHi7OwslSpVUsKFiEhUVJTO9z71Ew4t7UHy7Nmzcvr0aendu7csWLBA+fzOnTtKuJg6daqIiDx58oRV8tKxZcsWadiwoZQsWVKKFy+e6k7E/PnzJXfu3DJixAjl4Ejv9vXXX4utra00btxYSpQoIQULFpTJkyfLkydP5NmzZzJhwgSxsbFJVS2K0nfw4EHJly+fTrg4f/689OvXT/Lly6dUi+KxJ21hYWGSK1cuCQkJkUOHDsn69eulRIkS0rx5czl06JAy3rlz5yQ6OlqePn2qx9Jmb0OHDpWSJUtKr169xNPTUzQajYwZM0Zev34tz549k71790r37t1l4MCBMmXKFOXYzWO4OgwWOZQ2kafcACIiIsTOzk7MzMyUK8MiIgkJCUq4aNOmzUcva07Vv39/6dSpk86wyMhIcXJyklq1asmpU6dSVadI6yrep2z9+vVibm4uBQoUEGtra+nbt6/O5xERETJ+/HjJnz+/fPfdd3oqZfZ36tQpsbKyki+++EL69OkjuXPnli+//DLVHYnp06eLtbW1PHjwQE8lzTl27twpjo6O8scffyjb8ejRo6VcuXIye/ZsERG5d++ejBw5Uho2bMhtOw1TpkxJtU2LJJ8cW1lZia+vr3KMunjxovj6+oq9vb1OuwHSNXr0aKlTp47OsNDQUClWrJjUr19f9u/fr5+C5TC//PKLWFlZycmTJ5Xte/bs2aLRaOSbb76RmJiYNL/HOxXqMVjkYHfu3JHSpUsrDV8fPXok8+bNEycnp1QnxAkJCfLLL7+IRqOR//3vf/oobraV3glD+/btpX79+sp77e37RYsWiUajkYYNGyondjzp+Id2WTx79kyqVasmy5Ytk6NHj8rEiRMlT548MmrUKJ3xb9++LZMnT5Zr167po7jZ3tWrV2Xs2LEyefJkZdjixYulUKFCMnz48FThgg3eUwsICEhVB33VqlVSsmRJefDggc7JxODBg8XJyUnp/OLx48fKOv2pb+dvX0j54YcfxMDAQL7++mtlmHYZjRkzRjQajTRv3lz57MqVK/LZZ59J0aJF5cWLF5/88kzLpEmTpFq1avLy5UtJSkpSlvnKlSvF1NRUGjRowHCRAZs2bZISJUrIo0ePdNbbadOmSe7cuWXq1KlKmwvKWgwWOdjt27fF09NTChcurJyUPX78WBYtWiRWVlby5Zdf6oyfkJAge/bskcuXL+ujuNnW21cotO9DQ0PFwsJC5syZo/P5unXr5PPPPxcnJydp167dRytnTrJnzx7x9fWVXr16yaNHj0Qk+YR39uzZkjdv3lThgleJdGlPuP7++2+pUqWK2NrayogRI3TGWbhwoTg6OsqoUaN0QhlP1nT99ttv0qVLl1TVGxYtWiQFChSQZ8+eicg/veg9ePBALC0tZffu3Trjf+rLNeXJ2ZEjR5STsrVr14qxsbEMHTpUZ/y5c+dKp06dpEWLFjrL/tq1a3L37t2PU+gc4uLFi8r6tWnTJjEwMJBt27bpjLNt2zbx8PCQFi1aSEREhD6KmW2ltW1u375dcufOLZcuXRIRkfj4eBFJrpZnbm4uGo1GFi9e/FHL+algsMhhgoKCZNasWcr7mzdvire3txQoUEA5uXjy5IksWrRI8ufPnypckK4lS5aIh4eHbN68WcLDw3U+i46OljFjxoiLi4tMnz5dXr16Jffu3ZOmTZvK7Nmz5ddffxVTU1M5efKknkqffa1evVqMjY2lQIECOt38PX78WGbPni12dnYyaNAgPZYw+9u0aZOsW7dOQkJCxN3dXapWrZqqkeYPP/wgJiYmMnbsWNYLfgfticfGjRuVRrAvX76UokWLSpMmTXTGvXDhgri5ucmJEyc+ejmzq5QnbqNGjZJKlSrJnDlzJD4+XhISEmTNmjViYmIigwcPlocPH8qTJ0+kbdu2Ol3Kcv1M299//y0VKlSQ3r17K8t54MCBYmZmJps3b1buQI4ePVr8/f15R/IdVq1aJWvXrlXeN23aVCpWrCg3btxQht24cUNGjBgh69at4zr5L2GwyEFev34t/v7+otFodHbYN27cSBUutHcuChQoID169NBXkbMt7Q68Tp06YmJiIv3795eKFSuKv7+/nDt3Thnvxo0bShWeggULipOTk5QrV07evHkjv/32mxQtWlRu3rypr9nItuLi4mT9+vWSJ0+eVOH2yZMnMm3aNHFxcZGoqKhP/kqwVlJSkk5POgYGBrJ06VIREfnpp5/Ew8NDevfunapKz/Lly1M9B4SSpWzEfufOHSlWrJi0b99ejhw5IiIi+/btk4IFC0rt2rUlNDRU9u3bJ82aNRMvLy/eRUvDpEmTJF++fHLw4EGdE9w3b97Ixo0bxcrKSpycnMTFxUXKlSvHE7cMiI2NlXHjxknVqlVl4MCByj5g0KBBkitXLilbtqxUrFhR8uTJw96f3iE2NlY8PDykVq1ayjOSjhw5It7e3uLq6iqbN2+WrVu3io+PjzRs2FD5HtfRrMdgkcM8f/5cJk2aJBqNRkJCQpTh6YWL2bNni6urKx+ck46dO3dKv379JDw8XA4cOCAeHh7SqlUradasmfz1119KNYm///5bVq9eLVu3blV2RMOHD5cqVap88g1ltQfCBw8eSEREhM4J2apVq8TIyEiGDBmi850nT57o3Mmgfxw+fFi2bNkio0eP1hm+YsUKqVixovTq1Yvd8WZAyhPfNWvWSFxcnGzfvl2qVasmHTt2VO40njp1Sry8vKRgwYJSokQJadCgAbucfEtSUpJERkZKrVq1ZOXKlTqfpawidePGDZkzZ44sWbJE2U9yGepK60JKbGysTJ48WSpVqiSDBg1Sxtm5c6fMmzdPpk2bxosHb0lrOd66dUsaNGggderUkR07dohI8rM/unXrJtbW1uLu7i61a9dmr3n/MgaLHCLlzvvvv/+WkSNHikajkVWrVinDU4aL69evi0jywZW3TtN3/vx5KVeunGzYsEEZFhoaKhqNRjw8PJR+12NjY5XPL1y4IAMGDBArK6tP/gqSdue+efNmKVeunLi4uIizs7MEBgYqjYpXrVolxsbGOg08KdnkyZMlICBA5zkVNWrUEI1GIy1atBAR3W1/xYoV4uXlJe3bt5fz58/rpcw5waFDh8TMzEyio6Pl66+/loIFC8qdO3dEJLmuepUqVaRjx45y/Phx5TsXL16Umzdvptnj3qfo7RO3qKgocXR0lBUrVqQa9+XLl2nW+2eoSNvRo0clKChIZ1hsbKwEBwdLmTJlZOjQobyTm0Fvr3e3b9+WunXrSp06dWTnzp3K8OvXr0tkZCS374+AwSKH2bRpk3h4eEiHDh3ExMQkzWpRjRs3FiMjI516hZS+b7/9VkqWLKn0+lS2bFlp3LixrFy5UgYOHCgajUZGjhwpIslVKzZs2MCrxins27dPTExMZMqUKbJ//34ZNWqUVK5cWXx9fZVqYmvXrhWNRpPqKvynbsaMGaLRaGTatGnKsIsXL8pnn30m+fPnVzpaSHmFbfHixVK3bl32aPIO9+7dk5YtW4qNjY1YWVml6jlLGy46d+4sv/32W6rvp/dU7k9FyvmPi4sTEZG7d+9K0aJFlRPilKHh+PHjMmbMGKWjBkqWXjgYPHiwlCpVSnl+j9bLly+lQ4cOStfcDBeppVw3Fy5cKDVr1pTDhw/rjHPz5k0pX768VKhQQTZv3vzOaVDWY7DIQc6cOSOmpqaycOFCefTokZw9e1a+/vrrVOHi+vXr0rp1a946fcvbO2ntzuXChQvStGlT2bFjh5QrV05q1Kihc5cnPDxc5yD6+vVr5WD7KdN2hdi3b1/p3r27zmdLly6VihUrKifMr169kvXr18vFixf1UNLsSbs+hoSEiIGBgUyZMkVZJ69evSo1a9YUFxcXJUCkDBfp9cFO/wgICBCNRiM2NjZy69YtEdG9Srlt2zapVq2aNGrUSOeBl5+6lCddU6ZMkd69eytXhadPny65cuWS9evXK+M8f/5cmjRpIl26dOGJcBru37+vLL8NGzbIihUr5NGjRzJkyBDx8vLS6UZaRGTWrFlSqlQpad68udy/f18fRc4R7t27J1euXBFXV1dp3bp1qgsEe/fuFTMzM6lUqZLyUEb6OBgscpBt27ZJ6dKldU4qnjx5IkOHDhWNRiNr1qxRhvM2n663r1Bou57T6tSpk2g0GmnUqJHO8k35PS7TtPXo0UN58OLbzwMoXry4voqVraXsn/7Jkycybtw4MTAwUB7MJpLcLWf16tWlaNGiSrjgOpi+t581ceXKFTl48KB89tlnYmtrq1QdS/nE5507d0qvXr14BTMNI0aMkAIFCsj8+fOVO48vXryQESNGiEajkU6dOknnzp2ldu3aUqZMGSX4Mlz849mzZ+Lg4CDdu3eXkJAQ0Wg0smzZMhFJftjqV199JVWrVtWpFuXv7y+TJ09mG7S3/Pzzz0pnFkOHDpVmzZqJiMjZs2fF3d1dWrRooRMutm3bJp07d5ZBgwZx+/7IGCxykL1794qBgYHSa5F2B37ixAnJlSuXaDQaWbJkiT6LmC2l3KnMmDFDfH19pVy5crJgwQKli9mrV6+Kl5eXLFy4UF/FzHG069+oUaOkUKFCytU17fJev369lC1blm183mHDhg1SvHhx6datm+TPn1+5c6F17do1qV27tlhbW7MDhnd4+8Qh5d2dW7duSbNmzcTW1lbnGT7ff/+9Ttspnnz848CBA1KoUCGla963rV+/Xnr16iWdO3eW0aNHK4GXwTdZeHi4UrX27NmzYmJiIoaGhvL999+LyD/7zsjISPHz85Ny5copVZzNzMzk6tWr+ip6tvT69Wv55ptvRKPRSNOmTcXc3FzOnDmjfH727FkpWbKktGzZUlasWCG3b9+WFi1a6FQ14/b98TBYZFNpXfV59uyZ1K1bV3x9fXWqOUVEREjnzp1l6tSpcuHChY9ZzBxl5MiRYm9vL1OnTpXp06eLtbW1dO3aVR4+fChPnz6VVq1aSdeuXfVdzGxLu07ev39foqKidBrNlS1bVry8vOTu3bvKSd3AgQOlZs2a8vz5c72UN7s7d+6cWFhYyMKFC+XZs2dy584dCQ4OThUuLl++LD4+PjzZSEfKE4b58+dLt27dpHXr1vLjjz8qwyMiIqR58+ZiZWUlP/zwg9SrV088PDzYuDgdq1atkgoVKsirV6+U7V67nLXLLL0Hi37qfvjhB/Hy8pLHjx/L69ev5dGjR2JgYCCGhobSv39/pRMBrcePH8vmzZulS5cu0qdPH1bLS+HLL7/UabdTrlw50Wg0MnHiRBFJXue0691ff/0ljRo1koIFC0qhQoXE09OTd9H0hMEiG9JuBIcOHZJp06bJoEGDZNu2bRIfHy/r16+XqlWrSpcuXeTkyZNy9+5d8ff3lypVqrDe9Tv8/vvv4ubmpvQCc/LkSTEwMNDpOvHYsWOi0Whk//79+ipmtpWy96dKlSpJ4cKFpWzZsjJs2DARSa52Uq5cOSlYsKDUq1dPmjdvLhYWFp98r1nvcvDgQXFzc0v1FOKgoCAxMDCQefPmKSdz7B7x/UaOHCkFCxaUgQMHypgxY0Sj0UhwcLCy7B49eiS9evWS8uXLS4sWLZThvJKZ2vLlyyVv3rxK2xTtM1YSExNl69atcvv2bT2XMHvTdhagvYv7+PFjOX78uOTKlUt69OiRKlxocTv/x507d6Rx48ZKteWEhATp16+f9OrVSzQajVItKjExUVluUVFREh4eLrt27VICB++ifXwMFtnUxo0bxcLCQvr06SNNmjSRSpUqSYcOHUQk+YpIkyZNRKPRiLu7u+TNm1fntiCl9ttvv4mXl5eIJD9szNzcXObPny8iyd38hYaGyq1btyQgIIBX3tLx66+/irGxscyaNUvWrFkjs2bNEjMzM/H19VXGCQoKEj8/Pxk5cqRcunRJj6XNnlJeOTt8+LBoNBpl29Wud1euXBFLS0vRaDRK1QnSpa1mol2ea9asERcXF+XCwZ49e0Sj0YhGo5Fhw4bpnLBFREQo3/vUTzrOnDkj69evlylTpsjixYvl4cOH8vr1a7lw4YIUL15cxo4dq3Nn8tWrV1K7dm359ttv9Vjq7CvlenbmzBlxdXWVFStWKM9DCg0Nldy5c0vv3r2VcDF58mSZM2eOiPDKenqWL18uUVFRIpK8jLTVorThQivlw21FeBdNXxgs9Cytq2VXr14VV1dX5QF4N2/eFHNzc53nACQkJMjhw4fl4MGD6V79+FSltUz37NkjRYoUkVWrVomVlZXMmzdP+WzXrl3SoUMHnQPop37CkZavvvpKJ0SIJN9Vy5MnD7uRfY+3GxZr/23atKl4e3vr9JalvbI+c+ZMVm1Mw/Dhw2XMmDHKydrLly9l4cKFyja9Y8cOpcrTjz/+KBqNRoKCglL15Pap36lYunSpODs7i5eXlxQqVEgMDAzExcVF6UBg2rRpUrx4cenfv7/s2rVLfv31V2nYsKFUqFCB+8cU0lqPoqOjRUSkcePGUrFiRVm1apWyvh44cEDy5MkjDRs2lDZt2oipqanS1o9Se/z4sZiZmUnNmjWVcBEXFycBAQFiaGgoISEh8vDhQ2ndunWq3glJPxgs9Ei7Q7px44Zs3bpVGf7bb79JqVKlRCT5lmrhwoWlb9++yufHjh3T6dmE/pFyJ79u3TrZtGmT8r5169ZK9Qitly9fSvPmzaVt27af/InGu7x+/VoaNWokrVu3VoZprwZNnjxZqlatKg8fPlSWIa+8/UO7LMLCwmTMmDHSr18/mTdvnsTHx8vBgweVJ8UePXpULl26JP7+/lK6dGmdhsWULCkpSbp27SpVqlSRqVOnKidrERER8vfff8u9e/ekfPny8t1334lI8gMwtXd/5s6dq8+iZyurV68WU1NTWbNmjTx+/Fji4uLk8uXLUrNmTbGwsJAZM2aIiMicOXPEx8dHNBqNVKxYURo2bMinkqfh6tWrEhAQICLJDdtr1aqlrJutW7eWsmXL6oSLo0ePSrdu3aRbt258HtJbUh47tOva5cuXpWjRolK3bl2dcBEUFCQajUZKly4tpUqVYlWybILBQs/u3r0rtra2UrJkSaW+f3h4uNSuXVsuXrwoTk5O0rdvX2UnfuLECRkyZIhO7yaULOUOafjw4eLs7CwhISFKV5179+6VWrVqScmSJWXDhg0yf/588fHxkdKlSytX4Bguku+QLVu2TCZPnizXr19X6rguXLhQSpQoIYcOHdIZf8GCBVKyZEmeCL/Dxo0bxdzcXAYMGCA9evQQDw8PqVOnjoiIbNmyRdq2bSsajUbc3NzEwcFBTp8+rd8CZ0Pa7fvNmzfy5ZdfiqenpwQHB+usd6dOnZJSpUopDWD//vtvGTRokOzdu5dX2f9fdHS01KtXT2bNmiUiuvvNN2/eSN26dcXW1lZZhi9fvpQrV67I3bt3WYUsDYmJibJ48WIxMDCQNm3aiEajkeXLl+uMkzJcaDuzePnyJU+E35Ly+BscHCzz589X2o5euXJFihQpohMuRJLPiTZv3sw2FdkIg4WeHThwQAwMDKRy5crSqlUrWb16tSQkJEiRIkVEo9HIl19+qTP+0KFDpU6dOvLgwQM9lTj7+/bbb8XOzk6OHTuW6rNTp05Jx44dpUCBAlKrVi3p0aOHsnPnDknkzz//FGdnZ6lcubJYWVlJwYIFZfv27SKS3ADe29tbunTpotMN5ddffy316tVjsEjHrVu3pFSpUkpVnRs3boitra0MGDBAZ7yTJ0/KmTNnUjXmpmSJiYk6PRN9/vnn4unpKVOmTFGuBIeHh4tGo5E5c+ZIeHi4NG3aVJo0aaJMg9t4ctjKnz+/sl1raZfN06dPxdraOtX6qcWLL6m9efNGevfuLRqNRnm+gsg/bYFEksNFhQoVZMmSJTrDKVnK9So6Olrq1Kkjtra2snz5ciWMacNFvXr10ux+m3fRsgcGi2ygV69e4uHhIW3btpXatWvLrl275MyZM1K4cGHp2LGjhIeHy5EjR+Trr78WKysr3jpNR1JSkjx79kyaNGki06dPF5Hkp5Bv2bJFWrVqJb169VLqWd+7d48Pv3vLn3/+KXny5JGAgACJjo6WO3fuiLOzs9SsWVMZZ8uWLdKwYUNxdnaW+vXrS9OmTcXKyoqdB7wl5VXgM2fOiJubmyQkJMitW7fEyclJ+vXrp3y+b98+Xrn8ANqutt8OF9orm8HBwaLRaMTV1ZVdTqbhxIkTYmNjI2FhYSKi2+BY+//27dtL8+bN5fXr11xuGfDmzRsZM2aMdO3aVWxtbXXaQ7548UL5f8OGDaVq1arswfEd/Pz8pHr16tKhQwdxc3MTU1NTWbJkiU64KFq0qJQtW1anK1rKPhgsPqK3r/Ro20ns3LlTevToIXv27JE2bdpIrVq1ZNmyZXLo0CFxdXUVR0dHKV68uHh5efEE7i1pXT1r3769+Pj4yI8//iiNGzeW+vXrS6dOnaRo0aLSsGFDEdG9ssEDZ3IddY1GI59//rnO8Lp164qTk5PO3YjLly/LihUr5H//+5+MHTtWp+Hxp+rtbmFTrpeXL1+WBg0aSFhYmBIqtEH2r7/+kv79+7PqUwZt3LhRSpQoITt27BAR3XARHBysnHz89ddfEh4ervwdeOHgH7GxsVK4cGFp27atMuztK72dOnWSLl26fOyi5XixsbEyd+5cyZs3r064EBGl+k7KTkJI108//SSWlpZy+vRpef78ucTHx8sXX3whRkZGsmTJEuXO5IULF6RNmza8Q5FNMVh8JNoD3O3bt3UaFIsk3/Zzd3eXuXPnSlRUlLRp00bq1q0rO3fuVLr+u3Tpkjx+/FgfRc8RVq1aJYcPH1b+37x5c7G0tJRx48YpVaKmTZsm7dq1Y5BIQ2RkpLi7u4uXl5fcuHFDRJKXl0ajkfz580uvXr3Ey8tLFi1axPY9b9Fu25cuXZL+/ftLy5YtZcqUKUpvbU+fPpVSpUqJRqOR3r1763z366+/lurVq+vUGab07du3Tz777DOpUaOG7Ny5U0T+CReVK1eWqVOnytOnT3W+86lX3Xl7f/f69WsJCAhQ9o9ve/bsGbuUfQ/tMv3rr79k586dsnPnTuVC4YMHD2TevHmSL18+8fPzExGRgIAAqVevnnJiTGmbN2+eVK5cWV6+fKmz3fbp00esrKxk+fLlqZYhw0X2w2DxEd2+fVvy5cunPJZ+3bp1yknatm3bpFatWhIdHa2k8Xr16smyZcv0XOrs79mzZ2JrayvVq1eXP//8U0SS7wa93Q1vgwYNdHrXIl2RkZFSvnx58fLykhEjRij1sC9fvixXrlyRgQMHSr169USj0Ui3bt1Sdd/5KdIe/P744w+xsbERX19fad68uVSsWFGmT5+unIBcunRJ8uXLJ61atZKdO3fK/v37ZfDgwWJpaamss6QrvQsAhw8flnbt2knVqlV1wsXAgQOlSJEiOg+9/NSlPDmLjY1Vqo5ER0dLy5YtJW/evPL555/LgwcP5P79+3L16lVp1qyZlC9fnnd50qFdLzdt2iQuLi7i5uYmHh4eUqFCBXn48KGIiDx8+FAWLVokefLkkZIlS4qNjY2cPHlSn8XOEWbPni1WVlZKSNO2RTl+/LgYGBhIvnz5ZOPGjSLCQJGdMVh8RDdv3hRPT0+pVq2aVKxYUfr06SNFihSRhQsXyrp166R58+byyy+/iEhyN4ne3t7SokWLVFfgPnVpnXBERERIyZIlpXbt2spDskREYmJi5NChQ9KwYUMpW7ascrDkXYu03b9/X7y8vESj0ciKFStSff78+XPZsWMH71rIPydtf/75p5iZmcmYMWOUz/73v/9Jr169JDExUTnZ+P3336V06dLi4uIiJUqUkFq1avHJ5Bmwbt06+f3333WGHTp0SNq1aydVqlSRffv2iUjylfhvv/2WJxz/L+U+buLEidKkSROxt7eXAQMGSGhoqDx+/Fj69+8vFhYWki9fPsmXL594eXlJrVq12KXse+zbt0+srKxk0aJFkpiYKL/++qvywFrtBa2XL1/K+fPn5YcfflCexE3JUgbelP+PiYmRcuXKSbNmzZTeCEWS97EjRoyQPn36iK2tLe/wZnMaERHQR3P16lWMGjUKSUlJ8PX1hUajwaxZs2BtbY2tW7eiSpUqOHToEIyMjHD58mWYmZmhUKFC+i52thQTEwMrKyuICDQaDe7du4d69erBwcEB06ZNg5eXFw4cOIAff/wRcXFx+Omnn5A7d268efMGuXLl0nfx9U673BISEiAiMDY2BgBERUWhSZMm0Gg02LBhA1xcXJCUlAQDAwM9lzj7uXv3LpycnNC/f38sWLBAWaYDBgzA77//jqSkJGg0GkyYMAEtW7ZEbGwsHj16hFy5csHKygqWlpb6noVs7fLly+jWrRvy5cuHoKAgVKxYUfls//796N69OwoUKIDRo0ejdevWymeJiYkwNDTUQ4mzn7Fjx2LBggVYuHAhcufOjWnTpuHevXs4c+YMDAwMEBkZib179yJXrlxwc3NDnTp1YGBgwP1kOp49ewZ/f384Ojpi9OjRuHfvHqpVq4aaNWvi6tWrePLkCQ4dOoQCBQrou6jZknYfCQALFy7E8ePH4ebmhsaNG6NChQrYunUrJkyYAHNzc8yaNQsvX77EhAkTkC9fPkyfPh2lS5fG9OnT0b17dz3PCaVLj6Hmk3Xp0iVp0qSJNGrUSC5fvizPnz+XY8eOSfPmzZXb+Lyi/m7fffed1KlTR65fv64z/N69e+Lk5CR16tSRU6dOiUhyLxJsxKlLu37t3LlTunXrJuXKlZPRo0fLli1bROSfalEeHh5KmwtKLa22KVOnThVjY2OZO3euTJ8+XVq3bi2GhoZpdn9MutLa7/3000/i4+MjzZo1U7ZprYYNG4qrq6vS6QD3m7quXr0qnp6esn//fhER2b9/v9LLjkj6dyQ+9XYp77N9+3Y5deqUPH78WCpWrCj9+/cXkeS7axqNRhwcHNhtdBpSbp+BgYFiaWkpHTt2FHt7e2nUqJFy/AkNDZUaNWpInjx5pEiRIlKlShV5/fq1PH78WIoXLy67d+/W1yxQBjBY6MmVK1ekUaNG0qhRI/ntt9/0XZwc5+zZs2JqaiqfffaZEi60B8P169eLgYGBeHp66vRYxIOlri1btoipqakEBgbK3LlzpUWLFmJvb6/U+b9//75UrFhRihQpIrdu3dJzabOvt9um2Nrayp49e5TPT506JTY2NjJt2jQ9ljL7S7l9Pn36VKcryS1btkj9+vWlefPmSs94T548ke7du8tPP/3EQPH/3t7HXbt2TVxdXeXp06eyadMmMTc3lwULFohIcjeoK1asYDWdNGiX49vPm3h7PduxY4dUr15duagQGhoqzZs3l1atWindIlNqp0+flu7duysdrpw7d05atWoldevW1enc5sSJE3Lt2jXl7+Hv769T3YyyJwYLPbpy5Yo0btxYfHx8lA2MUksvEPz1119iYWEhLVu21Llz8fPPP0uvXr2kU6dOrCOcjocPH0rdunVl5syZIpJ8Ipc/f34ZMmSIznj379+XmjVrprozRLrSapuiXW8fPHgg5cuXT7PNCqU2fvx4qVChgri7u0urVq3k3LlzIpJ8d83Hx0dKliwpgwcPltq1a0v16tWV5cwLB//4448/5NWrV3L58mUpU6aMBAUFiY2NjfKQRpHkk7Y2bdrI0aNH9VjS7CsiIkLat2+v3O1Jy7x58yRPnjzKnfDRo0dLz549lcbHlNqKFSukdu3aUrVqVZ22En/++ae0atVK6tevL6tXr9b5zqlTp2TAgAFibW3NLvdzAAYLPbty5Yo0b95cqlatyqoSaUh5srB3715ZtmyZ/PLLL3Lt2jURSb5zYWFhIa1bt5Y9e/ZIZGSktGzZUucAynCR2qNHj6R06dJy9uxZuXXrlhQsWFCnx6yUDbS5/HRpr1rGx8frnEBERkZKhQoVpGLFijpBbMyYMeLi4sK7PulIuY3PmzdPrK2tZebMmRISEiLly5cXd3d3pVOLo0ePysiRI6VWrVrSvXv3NJ8b8qnbtm2b2NraKg9mGzRokGg0GvH391fGiYuLk2bNmknTpk257NJx/fp1qVatmjRr1izdWgV3796VUqVKiZ2dnXh7e4upqSkfYPsev/76q3h6eoq1tbVS9Unr7Nmz0qZNGylXrpzs3btXGR4eHi5TpkzhM5NyCAaLbODixYvSrl07nni8w/Dhw6VQoUJSrFgxKVGihDg5OcmBAwdEJPk2aqlSpaRQoUJSsGBBqVixIp9knI47d+5IXFycREZGSvXq1WXlypVStGhR6dOnj3KC8ffff0uPHj1k165dei5t9vMhbVOio6Nl/PjxYmJiwgfgZcDevXtl9uzZsm7dOp3hjRo1kpIlS0p0dLQyLGWgY7spXYmJieLq6qo8Q+HZs2fSuXNnyZMnj4wcOVKGDh0q9evXl9KlSzOYvUfKWgUpw0XKu2RXr16VLl26SFBQkFy4cEFfRc2W0luvDh8+LNWqVZPmzZsrvbpphYeHy6hRo1Jd0OIxPedgsMgmUnatRsm0O6UVK1ZIvnz55NixYxIbGyvh4eHSvXt3MTExUXb29+7dk3379smWLVuUHRJPOHSdO3dOXFxclCe/DhkyRDQajc4TeEWS67GWKVNGbt++rY9iZntbt25V2qbMmzdPWrZsqdM2JTIyUipWrCgajUbMzMxSNTim1MLDw8XIyEg0Go3y7B5t/fY3b95IoUKFlO58U9Zz/9TbVrx94hYfHy9JSUkydepUadiwodKA+NWrVzJhwgRp0qSJtGzZUkaMGKHsH7mffLd3hYvXr1/L8OHDpWvXrhITE6PHUmY/KdfNffv2yfr162Xbtm3KRYEDBw5I9erVpXXr1hIaGprmNHi3PGdisKBsZ/fu3cpTxhMTE2XMmDHSrl07nXHu378vHTp0kLp166b5RHLukNLm5uamVHlKSEiQbt26ibm5ucycOVO+/fZbGTBggFhYWPD5CunIaNuUe/fuyWeffcb6wBmkfVqxvb29+Pr6KsO1VymbN28ugwcP1lPpsr+3r5RfvHhRrKysZPbs2TrD3677z/1kxqQVLuLj4+XLL78UjUbD7fwdhg0bJoULF5bChQuLs7OzODs7y19//SUiyY3da9asKW3btlWqO1LOx2BB2UpsbKyUKlVKnJ2d5cmTJyKS3CDO1dU11ZOely5dKoULF5b79+/roaQ5i/aOWEhIiNStW1epqxoTEyPDhw+XypUrS8WKFaVTp06sI/wObJuiXnrVI54+fSpz584VY2NjJURo70iUL19ehg8f/rGKmO2lXIY///yzuLq6SufOneXq1avKA1WnTJki5cqVk0uXLinj8m5P5qUMFwcOHJARI0aIqakpqzm+w9KlSyVv3rxy4sQJuXfvnpw/f16aNm0qDg4OcvPmTRFJ7gK5ePHiMmrUKD2XlrIKgwVlO+fPn5fKlSuLu7u7PH78WA4fPiylS5eWOXPm6DyFXDtc25CbUouMjNR5f+3aNXFwcJDJkyfrDH/06JEkJCSk6l6RkrFtStZIeUK8ZMkSGTVqlHTr1k3CwsIkNjZW3rx5I3PmzBFjY2OpW7eudOvWTdq3by9ubm6ssvP/1q5dKz179pTLly9LUlKSREdHy88//ywVKlSQ0qVLS/v27eWPP/6Qo0ePSo0aNZTuO9mOQj1tZys2NjZiZGQk4eHh+i5Stubv7y9dunTRGRYTEyO1a9eWmjVrKnckz5w5wwsx/yEMFpRtpHyI3c2bN6Vy5cpSs2bN/2vvzoOirP84gL+fBYwgAQ9GMA9AV8AFEYQUFcEjucw0CRo7tCEYZIyRdDwy8R4TWlRUtMCRPMdjRjPCyTAt0f5IdKzkVPCACscRLDBE4PP7w/bJTS119bcG79cMM+yzzy4fntndZ9/f65G6ujqZOXOm+Pj4yJIlS6SkpEQqKiokNDRURo8ezZa3+ygsLJQhQ4ZIbGys1NTUSH19vYjcXnnH1dXVaLgTj+H9cW7K43Hna2zmzJnStWtXmTRpkgQGBkrXrl1lzpw5Ul1dLU1NTbJ+/Xrp2bOn6HQ6o2Em7T1cXL9+Xfr06SOOjo7i5eUlU6dOlR07dqj379q1SyZOnCi2trYye/Zs6dSpk3h5eTFUPEYlJSUyfvx4dTgP3V9CQoL0799fvW0ID59++qm4u7vLzz//bLQ/w0XbwGBBZnf16lX19zsnsYeFhYmiKDJ06FCpq6uTBQsWyKBBg0RRFBkwYID4+/tzVZM7FBcXy/vvv692MVdXV0tGRoZ4eHhI//79JS4uTs6ePSulpaUyatQo2bx5s4jww/xBcG7K45Ofny/Ozs5GQ0jS09PF29tblixZIiIiV65ckczMTHF0dJRZs2ap+7X393lzc7PMmzdPNm7cKIWFhZKWliYODg7y6quvSnp6uvp5mJubK1OnThU7Oztxd3dv98ftceMKRcbuPIff6auvvhKdTierVq0yahQ4ePCgeHp6shGmjWKwILP69ttvJSQkRL755huj7VFRUeLt7S35+fnqVY1ra2uloaFB8vLy5MSJE1z96Q5NTU0SEBAgiqKIVquV5ORk+fzzz9X7N2zYIJGRkWJjYyNLly6Vfv36ibu7O1cj+xecm2K6Y8eOiV6vF71eL6dOnZLvvvtO+vTpIxcvXjQKtYaLuBmG79XW1qoTuhMSEsxV/lMnLy9POnbsqK5C9scff8iCBQtEURQZOHCgrFy5UiorK6W5uVlKS0vVY8xwQU/Cvc7hht7J2tpaiYuLk5CQEFm0aJHU1dVJRUWFhIeHS3h4OHvK2ygGCzKrkpISCQ4OloiICHVZzkmTJolOp1NbM4qKimTgwIHi4+NzV8sIW9v/kpqaKunp6XLo0CFJSUkRBwcHiYmJkZycHPVLxY4dO2TixInSrVs3URRFXY6SjHFuyuORlZUljo6O4ufnJ7a2tqLVaiU6Olrc3NzUoWWGC7k1NDRI165dZe/everj6+rq5KOPPhI3NzepqanhF5E/JSYmSmJionq7f//+MmHCBJk1a5aMGTNGFEWRTZs2qffzc5KeFMM5/O8XEjS85mpqaiQpKUl0Op1YWVmJl5eX0bWmGHjbHgYLMjvDahuRkZEyfPhw8fX1lcrKSqN9iouLpUePHndNBKO/HDlyROzs7OT7778XkdtLnhou0DZ48GD55JNP5OrVq9LY2CgnT56U8vJyM1dsfvc6qXFuyuORlZUlHTp0kF27dklDQ4McOXJERo0aJYGBgeLi4iK+vr5G+1dWVopWq1UvfGlw/fr1ey4p3Z5lZ2fLsGHD5Nq1a+Lr6yvDhg1Tr6NQVVUlO3fuZE8u/d/c71ofhvBw8+ZN+f333yU1NVVOnTrF0QZtnAZEZqbVapGRkYGbN2/ixx9/xLx58+Di4gIAaG1tBQB4eHigoKAAW7ZsMWOlT7eQkBDEx8dj9erVaGxshLOzM4qLi+Hi4gIPDw9s2bIFzs7OWL9+PQYNGoS+ffuau2Sz02g0KCkpwfz583Hx4kUAgJOTEyZPnozjx49j5MiRSE5ORlFREcaMGQNXV1ecPn0aANDS0gJFUcxZ/lPr6NGjiI+Px/z58xEdHY1nn30WISEhGDt2LC5evIisrCwAgE6nw/79+7Fv3z5Mnz4d9vb2CAoKMnouOzs7dOrUyRz/xlMrNjYWTU1N6NKlC+zs7HDgwAHY2dkBAJ5//nm89tprsLS0RHNzs5krpfbAcA5XFAVLly5FQUEBAMDKygoigqtXryI6OhqVlZXw9fWFhYUFWlpaYGlpaebK6Ykwd7IhMjh37pyEhoZKeHi4HDt2TN3+91Zlduvf3549eyQwMFBaWlokNjZWunXrpq5eUlJSImvWrOFqJnfg3JQno6ysTIKCguTll182Gnv94YcfilarlaqqKikqKpLx48dL7969RafTSXh4uNrCyff4/Rl6ybZu3SpeXl7qEFL2npG53avn4tdff5URI0ZInz59OOm9nVBERMwdbogMysvLkZSUBAD44IMPMGzYMDNX9N8THByMgoICODk5IS8vDz4+PuYu6amWlpYGS0tLeHl5oaCgABkZGQgNDUV4eDjefPNNaDQa7Ny5E3v27MGJEydw5coVVFVVoXv37uYu/almeC+3trZi3bp1uHz5MiIiIrBt2zZERUWp+126dAnW1tZwdHSEoihobm5mS+YDqK6uRkBAAJKSkjB37lxzl0ME4K/3vaIomDZtGtauXYuqqiqcOXMGVlZWfH+3B+ZONkR/V1ZWJpGRkeLv76+ufEL/ztBi+cUXX0i/fv1k3759Rtvp3jg35ckpKyuT8PBw8fPzEysrK9m2bZuI3B5bbeiVuPP1yYmcDycjI0O6dOkiZ8+eNXcpRKqysjKJiIgQRVHE09NT7angnIr2gXMs6Kmj1WqRlpaGESNGwMvLy9zl/GcYxvsPGjQIra2tKCwsNNpO98a5KU+OVqvFmjVr4ODgAHd3d/XYWVpaQqO5ffq58/Vp2EYPJiIiApGRkfDw8DB3KUQqrVYLvV6P6dOn44cffmBPRTvDoVD01GttbeUXjoe0bds2JCQk4Ouvv8YLL7xg7nKeenv37kV6ejoKCgoQHx+P3NxcHD58GDqdDqWlpfjyyy8xevRo6HQ6c5f6n3Tu3Dm8++67ADjE8XETESiKgpaWFlhYWJi7HKK7MFS0LwwWRG1QdXU13njjDWzduhU9evQwdzn/CZyb8mSVl5cjOTkZNTU12LRpEwYMGGDukoiI6DFjsCBqoxobG2FtbW3uMp56hhbfvLw8JCcnY+XKlZgwYYK6nR6f4uJiZGdnIy0tjb2QRERtED/ZidoohooHw7kp/z+enp7Q6/XQaDTqNWqIiKjtYI8FEdGfODeFiIjo0bHHgojoTyNHjkRAQACvUUFERPQI2GNBRHQHzk0hIiJ6NAwWRERERERkMg6FIiIiIiIikzFYEBERERGRyRgsiIiIiIjIZAwWRERERERkMgYLIiIiIiIyGYMFERERERGZjMGCiIiIiIhMxmBBREQPbOrUqVAU5a6fc+fOmfzcOTk5cHBwML1IIiIyC0tzF0BERP8tYWFh2Lx5s9E2R0dHM1Vzb7du3YKVlZW5yyAialfYY0FERA/lmWeegZOTk9GPhYUFPvvsM/j5+cHa2hpubm5YvHgxmpub1celp6fD29sbtra26NmzJxITE1FfXw8AOHr0KN5++21cv35d7QVZtGgRAEBRFOzfv9+oBgcHB+Tk5AAALly4AEVRsGvXLgQHB8Pa2hrbt28HAGRnZ8PT0xPW1tbw8PBAZmam+hxNTU2YPn06nJ2dYW1tjd69e2PFihVP7sAREbVx7LEgIiKTHTt2DG+99RYyMjIQFBSE8+fPIz4+HgCwcOFCAIBGo0FGRgZcXV1RUVGBxMREzJ49G5mZmRg6dChWr16NlJQUlJaWAgCee+65h6ph7ty50Ov18PX1VcNFSkoK1q1bB19fX5w+fRpxcXGwtbXFlClTkJGRgQMHDmD37t3o1asXLl++jMuXLz/eA0NE1I4wWBAR0UPJzc01+tIfHh6O2tpazJ07F1OmTAEAuLm5YenSpZg9e7YaLGbMmKE+xsXFBcuWLUNCQgIyMzPRoUMH2NvbQ1EUODk5PVJdM2bMwCuvvKLeXrhwIfR6vbrN1dUVRUVF+PjjjzFlyhRcunQJWq0Ww4cPh6Io6N279yP9XSIiuo3BgoiIHsrIkSOxYcMG9batrS0GDBiA48ePY/ny5er2lpYWNDY24saNG7CxsUF+fj5WrFiBkpIS/Pbbb2hubja631T+/v7q7w0NDTh//jxiY2MRFxenbm9uboa9vT2A2xPRX3zxRbi7uyMsLAzjxo3D2LFjTa6DiKi9YrAgIqKHYmtri759+xptq6+vx+LFi416DAysra1x4cIFjBs3DtOmTcPy5cvRuXNnFBQUIDY2Fk1NTf8YLBRFgYgYbbt169Y967qzHgDIysrC4MGDjfazsLAAAPj5+aGyshIHDx5Efn4+oqOjMWbMGOzdu/dfjgAREd0LgwUREZnMz88PpaWldwUOg8LCQrS2tkKv10Ojub1uyO7du4326dChA1paWu56rKOjI3755Rf1dnl5OW7cuPGP9XTr1g3du3dHRUUFXn/99fvuZ2dnh5iYGMTExCAqKgphYWG4du0aOnfu/I/PT0REd2OwICIik6WkpGDcuHHo1asXoqKioNFocObMGfz0009YtmwZ+vbti1u3bmHt2rV46aWXcPz4cWzcuNHoOVxcXFBfX4/Dhw/Dx8cHNjY2sLGxwahRo7Bu3ToEBgaipaUFc+bMeaClZBcvXoykpCTY29sjLCwMN2/exMmTJ1FbW4v33nsP6enpcHZ2hq+vLzQaDfbs2QMnJydeS4OI6BFxuVkiIjJZaGgocnNzcejQIQQEBGDIkCFYtWqVOiHax8cH6enpWLlyJby8vLB9+/a7lnYdOnQoEhISEBMTA0dHR6SmpgIA9Ho9evbsiaCgIEyePBmzZs16oDkZ77zzDrKzs7F582Z4e3sjODgYOTk5cHV1BQB07NgRqamp8Pf3R0BAAC5cuIC8vDy1R4WIiB6OIn8fuEpERERERPSQ2CxDREREREQmY7AgIiIiIiKTMVgQEREREZHJGCyIiIiIiMhkDBZERERERGQyBgsiIiIiIjIZgwUREREREZmMwYKIiIiIiEzGYEFERERERCZjsCAiIiIiIpMxWBARERERkckYLIiIiIiIyGT/AxOAFDQH/97MAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 800x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot feature importances\n",
+    "plt.figure(figsize=(8, 6))\n",
+    "plt.bar(feature_names, importances, color='green')\n",
+    "plt.xlabel('Features')\n",
+    "plt.ylabel('Importance')\n",
+    "plt.title('Feature Importances for California Housing Dataset (OIKANRegressor)')\n",
+    "plt.xticks(rotation=45, ha='right')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "4b44d62e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:56.107827Z",
+     "iopub.status.busy": "2025-05-11T18:51:56.107515Z",
+     "iopub.status.idle": "2025-05-11T18:51:56.113601Z",
+     "shell.execute_reply": "2025-05-11T18:51:56.112634Z"
+    },
+    "papermill": {
+     "duration": 0.059425,
+     "end_time": "2025-05-11T18:51:56.114968",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:56.055543",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model saved to outputs/california_housing_model.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Save the model\n",
+    "model.save(\"outputs/california_housing_model.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "7a8263b8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:56.220386Z",
+     "iopub.status.busy": "2025-05-11T18:51:56.220006Z",
+     "iopub.status.idle": "2025-05-11T18:51:56.225598Z",
+     "shell.execute_reply": "2025-05-11T18:51:56.224583Z"
+    },
+    "papermill": {
+     "duration": 0.060836,
+     "end_time": "2025-05-11T18:51:56.227533",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:56.166697",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Load the model\n",
+    "loaded_model = OIKANRegressor()\n",
+    "loaded_model.load(\"outputs/california_housing_model.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "72e03f52",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:56.333342Z",
+     "iopub.status.busy": "2025-05-11T18:51:56.333015Z",
+     "iopub.status.idle": "2025-05-11T18:51:56.338073Z",
+     "shell.execute_reply": "2025-05-11T18:51:56.337067Z"
+    },
+    "papermill": {
+     "duration": 0.059539,
+     "end_time": "2025-05-11T18:51:56.339644",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:56.280105",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original Formula:\n",
+      "0.016541*x1 + 0.000361*x4 + -0.005436*x7 + 0.054910*x0^2 + 0.003279*x0 x1 + 0.000008*x0 x4 + 0.004007*x0 x5 + 0.000944*x0 x6 + -0.000631*x0 x7 + -0.000697*x1^2 + -0.001050*x1 x2 + 0.000003*x1 x4 + -0.000379*x1 x5 + -0.000428*x1 x6 + -0.000074*x1 x7 + 0.002858*x2^2 + -0.000023*x2 x4 + -0.003552*x2 x6 + 0.000169*x2 x7 + -0.000010*x3 x4 + 0.009420*x3 x5 + -0.003057*x3 x7 + 0.000011*x4 x5 + -0.000001*x4 x6 + 0.000003*x4 x7 + 0.000157*x5^2 + -0.000159*x5 x6 + 0.001021*x5 x7 + 0.000293*x6^2 + -0.000057*x6 x7 + 0.000018*x7^2 + 0.000030*exp_x5 + 0.049820*sin_x5 + -0.001212*x3^3 + -0.000013*exp_x3 + 0.000011*x1^3 + -0.003295*x0^3 + -0.000007*exp_x0 + -0.000005*x2^3 + 0.000014*exp_x2 + -0.000014*x6^3 + 0.000022*exp_x6 + -0.000017*exp_x4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Original formula\n",
+    "print(\"Original Formula:\")\n",
+    "formula_loaded = loaded_model.get_formula(type='original')\n",
+    "print(formula_loaded)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "5d353ff1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:51:56.446808Z",
+     "iopub.status.busy": "2025-05-11T18:51:56.446482Z",
+     "iopub.status.idle": "2025-05-11T18:52:07.999811Z",
+     "shell.execute_reply": "2025-05-11T18:52:07.998594Z"
+    },
+    "papermill": {
+     "duration": 11.609583,
+     "end_time": "2025-05-11T18:52:08.001498",
+     "exception": false,
+     "start_time": "2025-05-11T18:51:56.391915",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Simplified Formula:\n",
+      "0.00029*x6**2 + 0.04982*sin(x5) + 0.00286*x2**2 + 0.05491*x0**2 + 0.01654*x1 + 0.00016*x5**2 + 0.00036*x4 - 0.00070*x1**2 - 0.00544*x7 - 0.00330*x0**3 - 0.00121*x3**3 + 0.00102*x5*x7 + 0.00017*x2*x7 + 0.00094*x0*x6 + 0.00401*x0*x5 + 0.00942*x3*x5 + 0.00328*x0*x1 - 0.00006*x6*x7 - 0.00016*x5*x6 - 0.00355*x2*x6 - 0.00105*x1*x2 - 0.00007*x1*x7 - 0.00063*x0*x7 - 0.00038*x1*x5 - 0.00306*x3*x7 - 0.00043*x1*x6\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Simplified formula\n",
+    "print(\"\\nSimplified Formula:\")\n",
+    "simplified_formula = loaded_model.get_formula(type='sympy')\n",
+    "print(simplified_formula)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "63e03a39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-05-11T18:52:08.108263Z",
+     "iopub.status.busy": "2025-05-11T18:52:08.107461Z",
+     "iopub.status.idle": "2025-05-11T18:52:08.146097Z",
+     "shell.execute_reply": "2025-05-11T18:52:08.144822Z"
+    },
+    "papermill": {
+     "duration": 0.094054,
+     "end_time": "2025-05-11T18:52:08.147678",
+     "exception": false,
+     "start_time": "2025-05-11T18:52:08.053624",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "LaTeX Formula:\n",
+      "- 0.0033 x_{0}^{3} + 0.05491 x_{0}^{2} + 0.00328 x_{0} x_{1} + 0.00401 x_{0} x_{5} + 0.00094 x_{0} x_{6} - 0.00063 x_{0} x_{7} - 0.0007 x_{1}^{2} - 0.00105 x_{1} x_{2} - 0.00038 x_{1} x_{5} - 0.00043 x_{1} x_{6} - 7.0 \\cdot 10^{-5} x_{1} x_{7} + 0.01654 x_{1} + 0.00286 x_{2}^{2} - 0.00355 x_{2} x_{6} + 0.00017 x_{2} x_{7} - 0.00121 x_{3}^{3} + 0.00942 x_{3} x_{5} - 0.00306 x_{3} x_{7} + 0.00036 x_{4} + 0.00016 x_{5}^{2} - 0.00016 x_{5} x_{6} + 0.00102 x_{5} x_{7} + 0.00029 x_{6}^{2} - 6.0 \\cdot 10^{-5} x_{6} x_{7} - 0.00544 x_{7} + 0.04982 \\sin{\\left(x_{5} \\right)}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# LaTeX formula\n",
+    "print(\"\\nLaTeX Formula:\")\n",
+    "latex_formula = loaded_model.get_formula(type='latex')\n",
+    "print(latex_formula)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d312ccba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0523,
+     "end_time": "2025-05-11T18:52:08.252759",
+     "exception": false,
+     "start_time": "2025-05-11T18:52:08.200459",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Potential Improvements:\n",
+    "\n",
+    "* Add data preprocessing & feature engineering steps;\n",
+    "* Make visualizations using `matplotlib` / `seaborn`;\n",
+    "* Experiment with different hyperparameter values for better performance.\n",
+    "\n",
+    "\n",
+    "🙌 Thank you for using `OIKAN`! "
+   ]
+  }
+ ],
+ "metadata": {
+  "kaggle": {
+   "accelerator": "none",
+   "dataSources": [],
+   "dockerImageVersionId": 31012,
+   "isGpuEnabled": false,
+   "isInternetEnabled": true,
+   "language": "python",
+   "sourceType": "notebook"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 237.228317,
+   "end_time": "2025-05-11T18:52:10.230716",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "__notebook__.ipynb",
+   "output_path": "__notebook__.ipynb",
+   "parameters": {},
+   "start_time": "2025-05-11T18:48:13.002399",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/regression_tutorial.py
+++ b/examples/regression_tutorial.py
@@ -57,7 +57,7 @@ loaded_model.load("outputs/california_housing_model.json")
 formula_loaded = loaded_model.get_formula(type='original')
 print("> Symbolic Formula (loaded):", formula_loaded)
 
-simplified_formula = loaded_model.get_formula(type='sympied')
+simplified_formula = loaded_model.get_formula(type='sympy')
 print("Symbolic Formula (simplified):", simplified_formula)
 
 latex_formula = loaded_model.get_formula(type='latex')

--- a/oikan/model.py
+++ b/oikan/model.py
@@ -448,6 +448,8 @@ class OIKANRegressor(OIKAN):
         if self.verbose:
             print(f"Augmented data: features shape: {X_aug.shape} | target shape: {y_aug.shape}")
         self._perform_symbolic_regression(X_aug, y_aug)
+        if self.verbose:
+            print("OIKANRegressor model training completed successfully!")
 
     def predict(self, X):
         """
@@ -500,6 +502,8 @@ class OIKANClassifier(OIKAN):
         if self.verbose:
             print(f"Augmented data: features shape: {X_aug.shape} | target shape: {logits_aug.shape}")
         self._perform_symbolic_regression(X_aug, logits_aug)
+        if self.verbose:
+            print("OIKANClassifier model training completed successfully!")
 
     def predict(self, X):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "oikan"
-version = "0.0.3.4"
+version = "0.0.3.5"
 description = "OIKAN: Neuro-Symbolic ML for Scientific Discovery"
 readme = "README.md"
 authors = [{name = "Arman Zhalgasbayev"}]


### PR DESCRIPTION
### Changelog:

* Implemented complete tutorial for `OIKAN v0.0.3` library in classification and regression tasks on Google Colab and Kaggle + Jupyter Notebooks in GitHub;
* Added "Model training completed successfully!" message in verbose mode for `OIKANRegressor` and `OIKANClassifier` fitting processes;
* Made a hotfix to example tutorials: changed from `sympied` to `sympy`! 